### PR TITLE
Guard release tags against non-main commits

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,6 +25,11 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
+    - name: Ensure release tag is on main
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+        git merge-base --is-ancestor "$GITHUB_SHA" origin/main
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:


### PR DESCRIPTION
## Summary
- add an early Publish Release guard for tag-triggered runs
- fetch `main` and require the tagged commit to be an ancestor before minting release tokens or running GoReleaser
