### PR TITLE
fix: make yaml formatting side-effect free

### DIFF
--- a/pkg/cmd/cmdutil.go
+++ b/pkg/cmd/cmdutil.go
@@ -344,8 +344,7 @@ func formatJSON(res gjson.Result, opts ShowJSONOpts) ([]byte, error) {
 		if err := json2yaml.Convert(&yaml, input); err != nil {
 			return nil, err
 		}
-		_, err := opts.Stdout.Write([]byte(yaml.String()))
-		return nil, err
+		return []byte(yaml.String()), nil
 	default:
 		return nil, fmt.Errorf("Invalid format: %s, valid formats are: %s", opts.Format, strings.Join(OutputFormats, ", "))
 	}

--- a/pkg/cmd/cmdutil_test.go
+++ b/pkg/cmd/cmdutil_test.go
@@ -233,6 +233,50 @@ func TestFormatJSON(t *testing.T) {
 		require.NotContains(t, out, "\a")
 		require.Contains(t, out, `\u001b]52;c;ZGF0YQ==\u0007`)
 	})
+
+	t.Run("YAMLReturnsBytesWithoutWriting", func(t *testing.T) {
+		t.Parallel()
+
+		stdout, err := os.CreateTemp(t.TempDir(), "stdout")
+		require.NoError(t, err)
+		defer stdout.Close()
+
+		res := gjson.Parse(`{"id":"abc123","settings":{"enabled":true}}`)
+		formatted, err := formatJSON(res, ShowJSONOpts{Format: "yaml", Stdout: stdout})
+		require.NoError(t, err)
+		assert.Contains(t, string(formatted), "id: abc123")
+		assert.Contains(t, string(formatted), "enabled: true")
+
+		_, err = stdout.Seek(0, io.SeekStart)
+		require.NoError(t, err)
+
+		written, err := io.ReadAll(stdout)
+		require.NoError(t, err)
+		assert.Empty(t, written)
+	})
+}
+
+func TestShowJSONYAML(t *testing.T) {
+	t.Parallel()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer r.Close()
+
+	res := gjson.Parse(`{"id":"abc123","settings":{"enabled":true}}`)
+	err = ShowJSON(res, ShowJSONOpts{
+		Format: "yaml",
+		Stderr: io.Discard,
+		Stdout: w,
+		Title:  "test",
+	})
+	w.Close()
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	assert.Contains(t, buf.String(), "id: abc123")
+	assert.Contains(t, buf.String(), "enabled: true")
 }
 
 func TestShowJSONIterator(t *testing.T) {


### PR DESCRIPTION
## Summary
- make YAML formatting return bytes like the other output formats instead of writing directly to stdout
- keep `ShowJSON` / iterator callers responsible for writing output, so YAML can be buffered, counted, and paged consistently
- add regression coverage for the formatter side effect and the `ShowJSON` YAML output path

No linked issue; I found this while looking for another runtime correctness fix after the currently open issues were already covered by existing PRs.

## Validation
- `go test ./pkg/cmd -run 'TestFormatJSON|TestShowJSONYAML|TestShowJSONIterator'`
- `go test ./... -run 'TestFormatJSON|TestShowJSONYAML|TestShowJSONIterator'`
- `go build ./...`

Note: I also attempted `go test ./...` locally, but this Windows environment is missing `/bin/bash` for the autocomplete tests and does not have the mock server running on `localhost:4010` for generated command tests.