### PR TITLE
fix(completion): hide internal commands and suppress fish debug logs

### DIFF
--- a/internal/autocomplete/autocomplete.go
+++ b/internal/autocomplete/autocomplete.go
@@ -216,7 +216,9 @@ func getAllPossibleCompletions(completionStyle CompletionStyle, root *cli.Comman
 	completions := make([]ShellCompletion, 0)
 	if len(args) == 0 {
 		for _, child := range root.Commands {
-			completions = builder.createFromCommand("", child, completions)
+			if !child.Hidden {
+				completions = builder.createFromCommand("", child, completions)
+			}
 		}
 		return CompletionResult{Completions: completions, Behavior: ShellCompletionBehaviorDefault}
 	}

--- a/internal/autocomplete/autocomplete_test.go
+++ b/internal/autocomplete/autocomplete_test.go
@@ -241,6 +241,18 @@ func TestBashCompletionScriptDoesNotRegisterPlainCompletion(t *testing.T) {
 	assert.False(t, strings.Contains(completionScript, "\ncomplete -F __openai_bash_autocomplete openai"))
 }
 
+func TestFishCompletionScriptDoesNotWriteDebugLogs(t *testing.T) {
+	t.Parallel()
+
+	completionScript, err := shellCompletions[CompletionStyleFish](&cli.Command{}, "openai")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Contains(t, completionScript, "2>/dev/null")
+	assert.NotContains(t, completionScript, "fish-debug")
+}
+
 func TestGetCompletions_NonBoolFlagValue(t *testing.T) {
 	t.Parallel()
 

--- a/internal/autocomplete/autocomplete_test.go
+++ b/internal/autocomplete/autocomplete_test.go
@@ -17,6 +17,7 @@ func TestGetCompletions_EmptyArgs(t *testing.T) {
 			{Name: "generate", Usage: "Generate SDK"},
 			{Name: "test", Usage: "Run tests"},
 			{Name: "build", Usage: "Build project"},
+			{Name: "internal", Usage: "Internal command", Hidden: true},
 		},
 	}
 

--- a/internal/autocomplete/shellscripts/fish_autocomplete.fish
+++ b/internal/autocomplete/shellscripts/fish_autocomplete.fish
@@ -7,7 +7,7 @@ function ____APPNAME___fish_autocomplete
     set -l cmd $tokens[1]
     set -l args $tokens[2..-1]
 
-    set -l completions (env COMPLETION_STYLE=fish $cmd __complete -- $args $current 2>>/tmp/fish-debug.log)
+    set -l completions (env COMPLETION_STYLE=fish $cmd __complete -- $args $current 2>/dev/null)
     set -l exit_code $status
 
     # Check for custom file completion patterns
@@ -48,4 +48,3 @@ function ____APPNAME___fish_autocomplete
 end
 
 complete -c __APPNAME__ -f -a '(____APPNAME___fish_autocomplete)'
-


### PR DESCRIPTION
## Summary
- filter hidden commands from shell completion when no argument has been typed yet
- discard stderr from fish's internal completion probe instead of appending it to `/tmp/fish-debug.log`
- add focused regressions for the empty-input filter and embedded fish script

## Why
The non-empty completion path already skips `child.Hidden`, but the initial empty-input branch did not. An initial tab press could therefore expose internal commands such as `__complete`, `@completion`, and `@manpages`.

The fish completion script also appended diagnostics from every tab-completion invocation to a fixed temporary file. Bash already suppresses the same internal probe's stderr. Applying the same behavior in fish avoids an unbounded cross-session debug log during normal CLI use.

## Validation
- `git diff --check`
- `go test ./internal/autocomplete -count=1`

## Remote Linux validation
- `git diff --check`
- `./scripts/bootstrap`
- `./scripts/lint`
- `./scripts/test`