### PR TITLE
fix(completion): stop fish from writing debug logs

### DIFF
--- a/internal/autocomplete/shellscripts/fish_autocomplete.fish
+++ b/internal/autocomplete/shellscripts/fish_autocomplete.fish
@@ -7,7 +7,7 @@ function ____APPNAME___fish_autocomplete
     set -l cmd $tokens[1]
     set -l args $tokens[2..-1]
 
-    set -l completions (env COMPLETION_STYLE=fish $cmd __complete -- $args $current 2>>/tmp/fish-debug.log)
+    set -l completions (env COMPLETION_STYLE=fish $cmd __complete -- $args $current 2>/dev/null)
     set -l exit_code $status
 
     # Check for custom file completion patterns
@@ -48,4 +48,3 @@ function ____APPNAME___fish_autocomplete
 end
 
 complete -c __APPNAME__ -f -a '(____APPNAME___fish_autocomplete)'
-


### PR DESCRIPTION
## Summary
- discard stderr from fish's internal completion probe instead of appending it to `/tmp/fish-debug.log`

## Why
The fish completion script currently writes diagnostics from every tab-completion invocation to a fixed temporary file. That leaves an unbounded, cross-session debug log behind during normal CLI usage and can retain command diagnostics unexpectedly. Bash already suppresses the same internal probe's stderr; fish should do the same.

## Validation
- `git diff --check`
- `go test ./internal/autocomplete -count=1`
- verified the embedded fish completion script no longer references `fish-debug`
