### PR TITLE
[codex] Harden GitHub Actions permissions

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -17,7 +17,14 @@ runs:
     - name: Configure Git for access to the Go SDK's staging repo
       if: github.repository == 'stainless-sdks/openai-cli'
       shell: bash
-      run: git config --global url."https://x-access-token:${{ steps.get_token.outputs.github_access_token }}@github.com/stainless-sdks/openai-go".insteadOf "https://github.com/stainless-sdks/openai-go"
+      env:
+        GITHUB_ACCESS_TOKEN: ${{ steps.get_token.outputs.github_access_token }}
+      run: |
+        {
+          echo "GIT_CONFIG_COUNT=1"
+          echo "GIT_CONFIG_KEY_0=url.https://x-access-token:${GITHUB_ACCESS_TOKEN}@github.com/stainless-sdks/openai-go.insteadOf"
+          echo "GIT_CONFIG_VALUE_0=https://github.com/stainless-sdks/openai-go"
+        } >> "$GITHUB_ENV"
 
     - name: Setup go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:
@@ -35,8 +37,10 @@ jobs:
 
       - name: Link staging branch
         if: github.repository == 'stainless-sdks/openai-cli'
+        env:
+          GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ github.ref_name }}
         run: |
-          ./scripts/link 'github.com/stainless-sdks/openai-go/v3@${{ github.ref_name }}' || true
+          ./scripts/link "$GO_SDK_REPLACEMENT" || true
 
       - name: Bootstrap
         run: ./scripts/bootstrap
@@ -63,8 +67,10 @@ jobs:
 
       - name: Link staging branch
         if: github.repository == 'stainless-sdks/openai-cli'
+        env:
+          GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ github.ref_name }}
         run: |
-          ./scripts/link 'github.com/stainless-sdks/openai-go/v3@${{ github.ref_name }}' || true
+          ./scripts/link "$GO_SDK_REPLACEMENT" || true
 
       - name: Bootstrap
         run: ./scripts/bootstrap
@@ -116,8 +122,10 @@ jobs:
 
       - name: Link staging branch
         if: github.repository == 'stainless-sdks/openai-cli'
+        env:
+          GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ github.ref_name }}
         run: |
-          ./scripts/link 'github.com/stainless-sdks/openai-go/v3@${{ github.ref_name }}' || true
+          ./scripts/link "$GO_SDK_REPLACEMENT" || true
 
       - name: Bootstrap
         run: ./scripts/bootstrap

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -12,14 +12,9 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-cli'
     runs-on: ubuntu-latest
     environment: publish
-    permissions:
-      contents: write
+    permissions: {}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-
       - uses: stainless-api/trigger-release-please@bb6677c5a04578eec1ccfd9e1913b5b78ed64c61 # v1.4.0
         id: release
         with:

--- a/scripts/utils/upload-artifact.sh
+++ b/scripts/utils/upload-artifact.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -exuo pipefail
+set -euo pipefail
 
 BINARY_NAME="openai"
 DIST_DIR="dist"
@@ -35,7 +35,7 @@ done
 
 (cd "$DIST_DIR" && zip -r "$FILENAME" "${relative_files[@]}")
 
-RESPONSE=$(curl -X POST "$URL?filename=$FILENAME" \
+RESPONSE=$(curl --fail-with-body -sS -X POST "$URL?filename=$FILENAME" \
   -H "Authorization: Bearer $AUTH" \
   -H "Content-Type: application/json")
 
@@ -46,14 +46,15 @@ if [[ "$SIGNED_URL" == "null" ]]; then
   exit 1
 fi
 
-UPLOAD_RESPONSE=$(curl -v -X PUT \
+if UPLOAD_STATUS=$(curl -sS -X PUT \
   -H "Content-Type: application/zip" \
-  --data-binary "@${DIST_DIR}/${FILENAME}" "$SIGNED_URL" 2>&1)
-
-if echo "$UPLOAD_RESPONSE" | grep -q "HTTP/[0-9.]* 200"; then
+  --data-binary "@${DIST_DIR}/${FILENAME}" \
+  --output /dev/null \
+  --write-out "%{http_code}" \
+  "$SIGNED_URL") && [[ "$UPLOAD_STATUS" == "200" ]]; then
   echo -e "\033[32mUploaded build to Stainless storage.\033[0m"
   echo -e "\033[32mInstallation: Download and unzip: 'https://pkg.stainless.com/s/openai-cli/$SHA'. On macOS, run 'xattr -d com.apple.quarantine {executable name}'.\033[0m"
 else
-  echo -e "\033[31mFailed to upload artifact.\033[0m"
+  echo -e "\033[31mFailed to upload artifact. HTTP status: ${UPLOAD_STATUS:-curl failed}.\033[0m"
   exit 1
 fi


### PR DESCRIPTION
## Summary

Harden the GitHub Actions configuration based on the workflow security audit:

- Set explicit read-only default `GITHUB_TOKEN` permissions for CI.
- Remove unnecessary checkout and `contents: write` from the release-creation dispatcher.
- Configure Stainless private-module git access through Git's `GIT_CONFIG_*` environment variables instead of writing credentials to runner home config.
- Pass branch-derived values through environment variables before shell use.
- Stop tracing artifact-upload commands and remove verbose curl output that could expose OIDC tokens or signed upload URLs.

## Validation

- `actionlint`
- `bash -n scripts/utils/upload-artifact.sh`
- YAML parse check for all workflow/composite action files
- SHA-pin scan for external `uses:` references
- `git diff --check`
- Fake-token git rewrite probe for the `GIT_CONFIG_*` URL rewrite

## Notes

All external GitHub Actions references remain pinned to full commit SHAs.