### PR TITLE
Fix unknown command suggestions

### DIFF
--- a/pkg/cmd/suggest.go
+++ b/pkg/cmd/suggest.go
@@ -101,6 +101,8 @@ func jaroWinkler(a, b string) float64 {
 // suggestCommand takes a list of commands and a provided string to suggest a
 // command name
 func suggestCommand(commands []*cli.Command, provided string) string {
+	const minSuggestionDistance = 0.75
+
 	distance := 0.0
 	var lineage []*cli.Command
 	for _, command := range commands {
@@ -111,6 +113,9 @@ func suggestCommand(commands []*cli.Command, provided string) string {
 				lineage = command.Lineage()
 			}
 		}
+	}
+	if distance < minSuggestionDistance || len(lineage) == 0 {
+		return ""
 	}
 
 	var parts []string

--- a/pkg/cmd/suggest_test.go
+++ b/pkg/cmd/suggest_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/urfave/cli/v3"
+)
+
+func TestSuggestCommandSkipsUnrelatedInput(t *testing.T) {
+	commands := []*cli.Command{
+		{Name: "completions"},
+		{Name: "responses"},
+	}
+
+	if got := suggestCommand(commands, "totallybogus"); got != "" {
+		t.Fatalf("expected no suggestion for unrelated input, got %q", got)
+	}
+}
+
+func TestSuggestCommandKeepsCloseMatches(t *testing.T) {
+	commands := []*cli.Command{
+		{Name: "create"},
+		{Name: "delete"},
+	}
+
+	if got := suggestCommand(commands, "creat"); got != "Did you mean 'create'?" {
+		t.Fatalf("expected create suggestion, got %q", got)
+	}
+}


### PR DESCRIPTION
Summary:
- Adds a maximum edit-distance threshold before suggesting a command for unknown input.
- Keeps close typo suggestions while avoiding unrelated suggestions.
- Adds regression coverage for close and distant unknown commands.

Testing:
- git diff --check
- Not run: `go test ./pkg/cmd -run TestSuggestCommand` because `go` is not installed in this local environment.

Fixes #16

AI assistance: This bug fix was prepared with AI assistance and reviewed before submission.
