### PR TITLE
fix(debug): redact sensitive response headers

### DIFF
--- a/internal/debugmiddleware/debug_middleware.go
+++ b/internal/debugmiddleware/debug_middleware.go
@@ -17,8 +17,8 @@ type (
 
 const redactedPlaceholder = "<REDACTED>"
 
-// Headers known to contain sensitive information like an API key. Note that this exclude `Authorization`,
-// which is handled specially in `redactRequest` below.
+// Headers known to contain sensitive information like an API key. Authorization
+// headers are handled separately so their authentication scheme remains visible.
 var sensitiveHeaders = []string{
 	"api-key",
 	"x-api-key",
@@ -55,7 +55,10 @@ func (m *RequestLogger) Middleware() Middleware {
 			return resp, err
 		}
 
-		if respBytes, err := httputil.DumpResponse(resp, false); err == nil {
+		loggedResponse := new(http.Response)
+		*loggedResponse = *resp
+		loggedResponse.Header = m.redactHeaders(resp.Header)
+		if respBytes, err := httputil.DumpResponse(loggedResponse, false); err == nil {
 			m.logger.Printf("Response Content:\n%s\n", respBytes)
 		}
 
@@ -68,38 +71,7 @@ func (m *RequestLogger) Middleware() Middleware {
 // the original and that clone is returned. As a small optimization, the
 // original is request is returned unchanged if no redaction is necessary.
 func (m *RequestLogger) redactRequest(req *http.Request) (*http.Request, error) {
-	redactedHeaders := req.Header.Clone()
-
-	// Notably, the clauses below are written so they can redact multiple
-	// headers of the same name if necessary.
-	if values := redactedHeaders.Values("Authorization"); len(values) > 0 {
-		redactedHeaders.Del("Authorization")
-
-		for _, value := range values {
-			// In case we're using something like a bearer token (e.g. `Bearer
-			// <my_token>`), keep the `Bearer` part for more debugging
-			// information.
-			if authKind, _, ok := strings.Cut(value, " "); ok {
-				redactedHeaders.Add("Authorization", authKind+" "+redactedPlaceholder)
-			} else {
-				redactedHeaders.Add("Authorization", redactedPlaceholder)
-			}
-		}
-	}
-
-	for _, header := range m.sensitiveHeaders {
-		values := redactedHeaders.Values(header)
-		if len(values) == 0 {
-			continue
-		}
-
-		redactedHeaders.Del(header)
-
-		for range values {
-			redactedHeaders.Add(header, redactedPlaceholder)
-		}
-	}
-
+	redactedHeaders := m.redactHeaders(req.Header)
 	if reflect.DeepEqual(req.Header, redactedHeaders) {
 		return req, nil
 	}
@@ -107,4 +79,30 @@ func (m *RequestLogger) redactRequest(req *http.Request) (*http.Request, error) 
 	redacted := req.Clone(req.Context())
 	redacted.Header = redactedHeaders
 	return redacted, nil
+}
+
+func (m *RequestLogger) redactHeaders(headers http.Header) http.Header {
+	redacted := headers.Clone()
+	for header, values := range redacted {
+		if strings.EqualFold(header, "Authorization") || strings.EqualFold(header, "Proxy-Authorization") {
+			for i, value := range values {
+				if authKind, _, ok := strings.Cut(value, " "); ok {
+					values[i] = authKind + " " + redactedPlaceholder
+				} else {
+					values[i] = redactedPlaceholder
+				}
+			}
+			continue
+		}
+
+		for _, sensitiveHeader := range m.sensitiveHeaders {
+			if strings.EqualFold(header, sensitiveHeader) {
+				for i := range values {
+					values[i] = redactedPlaceholder
+				}
+				break
+			}
+		}
+	}
+	return redacted
 }

--- a/internal/debugmiddleware/debug_middleware.go
+++ b/internal/debugmiddleware/debug_middleware.go
@@ -55,10 +55,9 @@ func (m *RequestLogger) Middleware() Middleware {
 			return resp, err
 		}
 
-		loggedResponse := new(http.Response)
-		*loggedResponse = *resp
+		loggedResponse := *resp
 		loggedResponse.Header = m.redactHeaders(resp.Header)
-		if respBytes, err := httputil.DumpResponse(loggedResponse, false); err == nil {
+		if respBytes, err := httputil.DumpResponse(&loggedResponse, false); err == nil {
 			m.logger.Printf("Response Content:\n%s\n", respBytes)
 		}
 
@@ -81,6 +80,7 @@ func (m *RequestLogger) redactRequest(req *http.Request) (*http.Request, error) 
 	return redacted, nil
 }
 
+// redactHeaders returns an independent copy with sensitive values removed.
 func (m *RequestLogger) redactHeaders(headers http.Header) http.Header {
 	redacted := headers.Clone()
 	for header, values := range redacted {

--- a/internal/debugmiddleware/debug_middleware_test.go
+++ b/internal/debugmiddleware/debug_middleware_test.go
@@ -212,15 +212,16 @@ func TestDebugMiddleware(t *testing.T) {
 			"X-Request-Id":        {"request-id"},
 		}
 		originalHeaders := responseHeaders.Clone()
+		response := &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     responseHeaders,
+			Body:       http.NoBody,
+		}
 
 		req := httptest.NewRequest("GET", "https://example.com", nil)
 		resp, err := middleware.Middleware()(req, func(req *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Status:     "200 OK",
-				Header:     responseHeaders,
-				Body:       http.NoBody,
-			}, nil
+			return response, nil
 		})
 		require.NoError(t, err)
 
@@ -232,6 +233,7 @@ func TestDebugMiddleware(t *testing.T) {
 		require.Contains(t, logged, "Bearer "+redactedPlaceholder)
 		require.Contains(t, logged, "Basic "+redactedPlaceholder)
 		require.Contains(t, logged, "X-Request-Id: request-id")
+		require.Same(t, response, resp)
 		require.Equal(t, originalHeaders, resp.Header)
 	})
 

--- a/internal/debugmiddleware/debug_middleware_test.go
+++ b/internal/debugmiddleware/debug_middleware_test.go
@@ -200,6 +200,41 @@ func TestDebugMiddleware(t *testing.T) {
 		require.NotContains(t, logBuf.String(), bodyContent)
 	})
 
+	t.Run("RedactsSensitiveResponseHeaders", func(t *testing.T) {
+		t.Parallel()
+
+		middleware, logBuf := setup()
+		responseHeaders := http.Header{
+			"sEt-CoOkIe":          {"session=" + secretToken + "1", "csrf=" + secretToken + "2"},
+			"aUtHoRiZaTiOn":       {"Bearer " + secretToken + "3"},
+			"pRoXy-AuThOrIzAtIoN": {"Basic " + secretToken + "4"},
+			"X-Api-Key":           {secretToken + "5"},
+			"X-Request-Id":        {"request-id"},
+		}
+		originalHeaders := responseHeaders.Clone()
+
+		req := httptest.NewRequest("GET", "https://example.com", nil)
+		resp, err := middleware.Middleware()(req, func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     responseHeaders,
+				Body:       http.NoBody,
+			}, nil
+		})
+		require.NoError(t, err)
+
+		logged := logBuf.String()
+		for _, suffix := range []string{"1", "2", "3", "4", "5"} {
+			require.NotContains(t, logged, secretToken+suffix)
+		}
+		require.Equal(t, 5, strings.Count(logged, redactedPlaceholder))
+		require.Contains(t, logged, "Bearer "+redactedPlaceholder)
+		require.Contains(t, logged, "Basic "+redactedPlaceholder)
+		require.Contains(t, logged, "X-Request-Id: request-id")
+		require.Equal(t, originalHeaders, resp.Header)
+	})
+
 	t.Run("DoesNotLogOrConsumeResponseBody", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Problem

Debug logging already clones and redacts request headers, but response headers were passed directly to httputil.DumpResponse. This exposed values such as Set-Cookie, response-side Authorization, and API-key headers whenever debug logging was enabled.

## Fix

- share one case-insensitive header redaction path across requests and responses
- redact direct and proxy authorization while retaining only the authentication scheme
- shallow-copy the response before logging so the response returned to callers is untouched
- keep ordinary response headers available for debugging

## Coverage

The response test covers multiple cookies, direct and proxy authorization, an API-key header, deliberately non-canonical casing, a visible request ID, and both header and response-object identity.

## Validation

- ./scripts/test
- go test -race ./internal/debugmiddleware -count=1
- go vet ./...
- ./scripts/lint