### PR TITLE
fix: keep API error output on stderr

### DIFF
--- a/cmd/openai/main.go
+++ b/cmd/openai/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"strings"
 
 	"github.com/openai/openai-cli/pkg/cmd"
 	"github.com/openai/openai-go/v3"
@@ -41,15 +42,17 @@ func main() {
 		var apierr *openai.Error
 		if errors.As(err, &apierr) {
 			fmt.Fprintf(os.Stderr, "%s %q: %d %s\n", apierr.Request.Method, apierr.Request.URL, apierr.Response.StatusCode, http.StatusText(apierr.Response.StatusCode))
-			format := app.String("format-error")
+			format := errorOutputFormat(app.String("format-error"))
 			json := gjson.Parse(apierr.RawJSON())
-			show_err := cmd.ShowJSON(json, cmd.ShowJSONOpts{
+			showErr := cmd.ShowJSON(json, cmd.ShowJSONOpts{
 				ExplicitFormat: app.IsSet("format-error"),
 				Format:         format,
+				Stderr:         os.Stderr,
+				Stdout:         os.Stderr,
 				Title:          "Error",
 				Transform:      app.String("transform-error"),
 			})
-			if show_err != nil {
+			if showErr != nil {
 				// Just print the original error:
 				fmt.Fprintf(os.Stderr, "%s\n", err.Error())
 			}
@@ -62,6 +65,13 @@ func main() {
 		}
 		os.Exit(exitCode)
 	}
+}
+
+func errorOutputFormat(format string) string {
+	if strings.EqualFold(format, "explore") {
+		return "json"
+	}
+	return format
 }
 
 func prepareForAutocomplete(cmd *cli.Command) {

--- a/cmd/openai/main_test.go
+++ b/cmd/openai/main_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIErrorOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid model","type":"invalid_request_error"}}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	binaryName := "openai"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	binary := filepath.Join(t.TempDir(), binaryName)
+	build := exec.CommandContext(ctx, "go", "build", "-o", binary, ".")
+	buildOutput, err := build.CombinedOutput()
+	require.NoError(t, err, "output: %s", buildOutput)
+
+	command := exec.CommandContext(
+		ctx,
+		binary,
+		"--base-url", server.URL,
+		"--api-key", "key",
+		"--format-error", "raw",
+		"models", "retrieve",
+		"--model", "missing",
+	)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	err = command.Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 1, exitErr.ExitCode())
+	require.Empty(t, stdout.String())
+	require.Contains(t, stderr.String(), "400 Bad Request")
+	require.Contains(t, stderr.String(), `"message":"invalid model"`)
+}
+
+func TestErrorOutputFormat(t *testing.T) {
+	require.Equal(t, "json", errorOutputFormat("explore"))
+	require.Equal(t, "json", errorOutputFormat("EXPLORE"))
+	require.Equal(t, "raw", errorOutputFormat("raw"))
+}


### PR DESCRIPTION
## Summary

- write formatted API error bodies to stderr alongside the HTTP status line
- fall back to JSON for `--format-error explore`, since the interactive explorer writes to stdout
- add an end-to-end regression test that keeps stdout empty on API failures

## Why

API failures currently split their output across streams: the status line goes to stderr, while the structured response body defaults to stdout. This makes failed commands unsafe to pipe because error JSON can be mistaken for successful output.

## Test plan

- `./scripts/test`
- regression test covers exit status, empty stdout, and the status plus JSON body on stderr