### PR TITLE
fix: install Linux package binaries under /usr/bin

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,7 +82,7 @@ snapshot:
 nfpms:
   - license: Apache-2.0
     maintainer: support@openai.com
-    bindir: /usr
+    bindir: /usr/bin
     formats:
       - apk
       - deb


### PR DESCRIPTION
## Summary

- install packaged Linux binaries under `/usr/bin`
- keep deb, apk, rpm, and Arch packages on the standard executable path

## Why

The nFPM configuration currently uses `/usr` as its binary directory, so packages place the executable at `/usr/openai`. That location is not normally on `PATH`, leaving a successful package installation without a directly runnable `openai` command.

## Test plan

- ran the pinned GoReleaser 2.15.4 snapshot release
- verified the generated deb, apk, and Arch packages contain `usr/bin/openai`