### PR TITLE
Run CI once per pull request

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -8,14 +8,14 @@ runs:
   using: composite
   steps:
     - uses: stainless-api/retrieve-github-access-token@1f03f929b746c5b03dcdafa2bebbb18ca5672e1a # v1
-      if: github.repository == 'stainless-sdks/openai-cli'
+      if: github.repository == 'stainless-sdks/openai-cli' && inputs.stainless-api-key != ''
       id: get_token
       with:
         repo: stainless-sdks/openai-go
         stainless-api-key: ${{ inputs.stainless-api-key }}
 
     - name: Configure Git for access to the Go SDK's staging repo
-      if: github.repository == 'stainless-sdks/openai-cli'
+      if: steps.get_token.outputs.github_access_token != ''
       shell: bash
       env:
         GITHUB_ACCESS_TOKEN: ${{ steps.get_token.outputs.github_access_token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   GOPRIVATE: github.com/openai/openai-go/v3,github.com/stainless-sdks/openai-go/v3
+  IS_TRUSTED_SOURCE: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
   SOURCE_BRANCH: ${{ github.head_ref || github.ref_name }}
 
 jobs:
@@ -33,8 +34,7 @@ jobs:
       - name: Link staging branch
         if: |-
           github.repository == 'stainless-sdks/openai-cli' &&
-          (github.event_name == 'push' ||
-            github.event.pull_request.head.repo.full_name == github.repository)
+          env.IS_TRUSTED_SOURCE == 'true'
         env:
           GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ env.SOURCE_BRANCH }}
         run: |
@@ -66,8 +66,7 @@ jobs:
       - name: Link staging branch
         if: |-
           github.repository == 'stainless-sdks/openai-cli' &&
-          (github.event_name == 'push' ||
-            github.event.pull_request.head.repo.full_name == github.repository)
+          env.IS_TRUSTED_SOURCE == 'true'
         env:
           GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ env.SOURCE_BRANCH }}
         run: |
@@ -91,8 +90,7 @@ jobs:
       - name: Get GitHub OIDC Token
         if: |-
           github.repository == 'stainless-sdks/openai-cli' &&
-          (github.event_name == 'push' ||
-            github.event.pull_request.head.repo.full_name == github.repository) &&
+          env.IS_TRUSTED_SOURCE == 'true' &&
           !startsWith(env.SOURCE_BRANCH, 'stl/')
         id: github-oidc
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -102,8 +100,7 @@ jobs:
       - name: Upload tarball
         if: |-
           github.repository == 'stainless-sdks/openai-cli' &&
-          (github.event_name == 'push' ||
-            github.event.pull_request.head.repo.full_name == github.repository) &&
+          env.IS_TRUSTED_SOURCE == 'true' &&
           !startsWith(env.SOURCE_BRANCH, 'stl/')
         env:
           URL: https://pkg.stainless.com/s
@@ -127,8 +124,7 @@ jobs:
       - name: Link staging branch
         if: |-
           github.repository == 'stainless-sdks/openai-cli' &&
-          (github.event_name == 'push' ||
-            github.event.pull_request.head.repo.full_name == github.repository)
+          env.IS_TRUSTED_SOURCE == 'true'
         env:
           GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ env.SOURCE_BRANCH }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   GOPRIVATE: github.com/openai/openai-go/v3,github.com/stainless-sdks/openai-go/v3
+  SOURCE_BRANCH: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   lint:
@@ -32,7 +33,7 @@ jobs:
       - name: Link staging branch
         if: github.repository == 'stainless-sdks/openai-cli'
         env:
-          GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ github.ref_name }}
+          GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ env.SOURCE_BRANCH }}
         run: |
           ./scripts/link "$GO_SDK_REPLACEMENT" || true
 
@@ -62,7 +63,7 @@ jobs:
       - name: Link staging branch
         if: github.repository == 'stainless-sdks/openai-cli'
         env:
-          GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ github.ref_name }}
+          GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ env.SOURCE_BRANCH }}
         run: |
           ./scripts/link "$GO_SDK_REPLACEMENT" || true
 
@@ -84,7 +85,7 @@ jobs:
       - name: Get GitHub OIDC Token
         if: |-
           github.repository == 'stainless-sdks/openai-cli' &&
-          !startsWith(github.ref, 'refs/heads/stl/')
+          !startsWith(env.SOURCE_BRANCH, 'stl/')
         id: github-oidc
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
@@ -93,7 +94,7 @@ jobs:
       - name: Upload tarball
         if: |-
           github.repository == 'stainless-sdks/openai-cli' &&
-          !startsWith(github.ref, 'refs/heads/stl/')
+          !startsWith(env.SOURCE_BRANCH, 'stl/')
         env:
           URL: https://pkg.stainless.com/s
           AUTH: ${{ steps.github-oidc.outputs.github_token }}
@@ -116,7 +117,7 @@ jobs:
       - name: Link staging branch
         if: github.repository == 'stainless-sdks/openai-cli'
         env:
-          GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ github.ref_name }}
+          GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ env.SOURCE_BRANCH }}
         run: |
           ./scripts/link "$GO_SDK_REPLACEMENT" || true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
     name: build
     permissions:
       contents: read
-      id-token: write
     runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata'
     steps:
@@ -87,21 +86,51 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Package release artifact
+        run: tar -cf openai-cli-dist.tar dist
+
+      - name: Stage release artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: openai-cli-dist
+          path: openai-cli-dist.tar
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 1
+
+  publish:
+    timeout-minutes: 10
+    name: publish
+    needs: build
+    if: |-
+      github.repository == 'stainless-sdks/openai-cli' &&
+      (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      !startsWith(github.head_ref || github.ref_name, 'stl/')
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Download release artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: openai-cli-dist
+          path: .artifacts/
+
+      - name: Restore release artifact
+        run: tar -xf .artifacts/openai-cli-dist.tar
+
       - name: Get GitHub OIDC Token
-        if: |-
-          github.repository == 'stainless-sdks/openai-cli' &&
-          env.IS_TRUSTED_SOURCE == 'true' &&
-          !startsWith(env.SOURCE_BRANCH, 'stl/')
         id: github-oidc
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: core.setOutput('github_token', await core.getIDToken());
 
       - name: Upload tarball
-        if: |-
-          github.repository == 'stainless-sdks/openai-cli' &&
-          env.IS_TRUSTED_SOURCE == 'true' &&
-          !startsWith(env.SOURCE_BRANCH, 'stl/')
         env:
           URL: https://pkg.stainless.com/s
           AUTH: ${{ steps.github-oidc.outputs.github_token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,7 @@ jobs:
     timeout-minutes: 10
     name: test
     runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    if: github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ on:
 env:
   GOPRIVATE: github.com/openai/openai-go/v3,github.com/stainless-sdks/openai-go/v3
   SOURCE_BRANCH: ${{ github.head_ref || github.ref_name }}
-  SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   lint:
@@ -109,7 +108,7 @@ jobs:
         env:
           URL: https://pkg.stainless.com/s
           AUTH: ${{ steps.github-oidc.outputs.github_token }}
-          SHA: ${{ env.SOURCE_SHA }}
+          SHA: ${{ github.sha }}
         run: ./scripts/utils/upload-artifact.sh
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
 env:
   GOPRIVATE: github.com/openai/openai-go/v3,github.com/stainless-sdks/openai-go/v3
   SOURCE_BRANCH: ${{ github.head_ref || github.ref_name }}
+  SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   lint:
@@ -31,7 +32,10 @@ jobs:
           stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
 
       - name: Link staging branch
-        if: github.repository == 'stainless-sdks/openai-cli'
+        if: |-
+          github.repository == 'stainless-sdks/openai-cli' &&
+          (github.event_name == 'push' ||
+            github.event.pull_request.head.repo.full_name == github.repository)
         env:
           GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ env.SOURCE_BRANCH }}
         run: |
@@ -61,7 +65,10 @@ jobs:
           stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
 
       - name: Link staging branch
-        if: github.repository == 'stainless-sdks/openai-cli'
+        if: |-
+          github.repository == 'stainless-sdks/openai-cli' &&
+          (github.event_name == 'push' ||
+            github.event.pull_request.head.repo.full_name == github.repository)
         env:
           GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ env.SOURCE_BRANCH }}
         run: |
@@ -85,6 +92,8 @@ jobs:
       - name: Get GitHub OIDC Token
         if: |-
           github.repository == 'stainless-sdks/openai-cli' &&
+          (github.event_name == 'push' ||
+            github.event.pull_request.head.repo.full_name == github.repository) &&
           !startsWith(env.SOURCE_BRANCH, 'stl/')
         id: github-oidc
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -94,11 +103,13 @@ jobs:
       - name: Upload tarball
         if: |-
           github.repository == 'stainless-sdks/openai-cli' &&
+          (github.event_name == 'push' ||
+            github.event.pull_request.head.repo.full_name == github.repository) &&
           !startsWith(env.SOURCE_BRANCH, 'stl/')
         env:
           URL: https://pkg.stainless.com/s
           AUTH: ${{ steps.github-oidc.outputs.github_token }}
-          SHA: ${{ github.sha }}
+          SHA: ${{ env.SOURCE_SHA }}
         run: ./scripts/utils/upload-artifact.sh
 
   test:
@@ -115,7 +126,10 @@ jobs:
           stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
 
       - name: Link staging branch
-        if: github.repository == 'stainless-sdks/openai-cli'
+        if: |-
+          github.repository == 'stainless-sdks/openai-cli' &&
+          (github.event_name == 'push' ||
+            github.event.pull_request.head.repo.full_name == github.repository)
         env:
           GO_SDK_REPLACEMENT: github.com/stainless-sdks/openai-go/v3@${{ env.SOURCE_BRANCH }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,7 @@ permissions:
 on:
   push:
     branches:
-      - '**'
-      - '!integrated/**'
-      - '!stl-preview-head/**'
-      - '!stl-preview-base/**'
-      - '!generated'
-      - '!codegen/**'
-      - 'codegen/stl/**'
+      - main
   pull_request:
     branches-ignore:
       - 'stl-preview-head/**'
@@ -24,7 +18,7 @@ jobs:
     timeout-minutes: 10
     name: lint
     runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    if: github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata'
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -55,7 +49,7 @@ jobs:
       contents: read
       id-token: write
     runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    if: github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -110,7 +104,6 @@ jobs:
     timeout-minutes: 10
     name: test
     runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   GOPRIVATE: github.com/openai/openai-go/v3,github.com/stainless-sdks/openai-go/v3
+  IS_PUBLISHABLE: ${{ github.repository == 'stainless-sdks/openai-cli' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !startsWith(github.head_ref || github.ref_name, 'stl/') }}
   IS_TRUSTED_SOURCE: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
   SOURCE_BRANCH: ${{ github.head_ref || github.ref_name }}
 
@@ -46,9 +47,11 @@ jobs:
       - name: Run lints
         run: ./scripts/lint
 
-  build:
+  build-artifacts:
     timeout-minutes: 10
-    name: build
+    name: build artifacts
+    outputs:
+      publishable: ${{ env.IS_PUBLISHABLE }}
     permissions:
       contents: read
     runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
@@ -87,9 +90,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package release artifact
+        if: env.IS_PUBLISHABLE == 'true'
         run: tar -cf openai-cli-dist.tar dist
 
       - name: Stage release artifact
+        if: env.IS_PUBLISHABLE == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: openai-cli-dist
@@ -101,11 +106,8 @@ jobs:
   publish:
     timeout-minutes: 10
     name: publish
-    needs: build
-    if: |-
-      github.repository == 'stainless-sdks/openai-cli' &&
-      (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      !startsWith(github.head_ref || github.ref_name, 'stl/')
+    needs: build-artifacts
+    if: needs.build-artifacts.outputs.publishable == 'true'
     permissions:
       contents: read
       id-token: write
@@ -136,6 +138,35 @@ jobs:
           AUTH: ${{ steps.github-oidc.outputs.github_token }}
           SHA: ${{ github.sha }}
         run: ./scripts/utils/upload-artifact.sh
+
+  build:
+    timeout-minutes: 10
+    name: build
+    needs:
+      - build-artifacts
+      - publish
+    if: |-
+      always() &&
+      (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    permissions:
+      contents: read
+    runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    steps:
+      - name: Require successful build and publication
+        env:
+          BUILD_RESULT: ${{ needs.build-artifacts.result }}
+          IS_PUBLISHABLE: ${{ needs.build-artifacts.outputs.publishable }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+        run: |
+          if [[ "$BUILD_RESULT" != "success" ]]; then
+            echo "Build artifacts failed: $BUILD_RESULT"
+            exit 1
+          fi
+
+          if [[ "$IS_PUBLISHABLE" == "true" && "$PUBLISH_RESULT" != "success" ]]; then
+            echo "Artifact publication failed: $PUBLISH_RESULT"
+            exit 1
+          fi
 
   test:
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

- run CI for feature and fork contributions through the `pull_request` event
- limit `push` CI to `main`, eliminating duplicate push and pull-request runs for the same PR commit
- keep the required check names stable as `lint`, `build`, and `test`

## Why

Same-repository PR branches previously triggered both `push` and `pull_request` workflow runs. The pull-request jobs were skipped, but still appeared as duplicate checks and could ambiguously satisfy required-check contexts.

After this change, a PR commit produces one CI run. The merged commit gets a separate post-merge run on `main`. Branches without an open PR no longer run this workflow until a PR is opened.

## Validation

- Actionlint v1.7.12
- YAML parsing
- `./scripts/lint`
- `./scripts/test`