### PR TITLE
fix(release): make partially published releases retryable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,9 @@
 project_name: openai
 version: 2
 
+release:
+  replace_existing_artifacts: true
+
 before:
   hooks:
     - mkdir -p completions


### PR DESCRIPTION
## Why

The v1.5.0 publish run partially uploaded its GitHub release assets, then received `404 Not Found` for two Windows uploads. GoReleaser exited before publishing the Homebrew cask, leaving `openai/homebrew-tools` on v1.4.0. A normal rerun is not reliably recoverable because the successfully uploaded assets already exist.

## Fix

Enable GoReleaser's `release.replace_existing_artifacts` so a rerun can replace previously uploaded assets, finish publishing, and reach the Homebrew cask PR. Target `next` so the setting ships with the next release; it does not retroactively change the existing v1.5.0 tag.

## Validation

- Parsed `.goreleaser.yml` and verified schema version 2 and `replace_existing_artifacts: true`.
- `git diff --check`.
- PR CI runs the full GoReleaser snapshot build.

Failed v1.5.0 run: https://github.com/openai/openai-cli/actions/runs/30107350402