### PR TITLE
fix(cmd): include backslash in path detection for @ file references

### DIFF
--- a/pkg/cmd/flagoptions.go
+++ b/pkg/cmd/flagoptions.go
@@ -234,7 +234,7 @@ func embedFilesValue(v reflect.Value, embedStyle FileEmbedStyle, stdin *onceStdi
 					// string literal and not a file reference. However, if the
 					// string looks like "@file.txt" or "@/tmp/file", then it's
 					// probably supposed to be a file.
-					probablyFile := strings.Contains(filename, ".") || strings.Contains(filename, "/")
+					probablyFile := strings.Contains(filename, ".") || strings.Contains(filename, "/") || strings.Contains(filename, "\\")
 					if probablyFile {
 						// Give a useful error message if the user tried to upload a
 						// file, but the file couldn't be read (e.g. mistyped
@@ -262,7 +262,7 @@ func embedFilesValue(v reflect.Value, embedStyle FileEmbedStyle, stdin *onceStdi
 				} else if withoutPrefix, ok := strings.CutPrefix(filename, "file://"); ok {
 					filename = withoutPrefix
 				} else {
-					expectsFile = strings.Contains(filename, ".") || strings.Contains(filename, "/")
+					expectsFile = strings.Contains(filename, ".") || strings.Contains(filename, "/") || strings.Contains(filename, "\\")
 				}
 
 				if isStdinPath(filename) {

--- a/pkg/cmd/flagoptions_test.go
+++ b/pkg/cmd/flagoptions_test.go
@@ -156,6 +156,14 @@ func TestEmbedFiles(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "non-existent file with backslash path @ prefix (error)",
+			input: map[string]any{
+				"missing": "@subfolder\\missingfile",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "non-file-like thing with @ prefix",
 			input: map[string]any{
 				"username":        "@user",


### PR DESCRIPTION
### Observed Behavior
When passing an `@` file reference containing backslash path separators (such as `@subfolder\\unreadablefile` or Windows paths without a file extension) that fails to open, `embedFilesValue` in `pkg/cmd/flagoptions.go` did not recognize `\\` as a path separator. As a result, `probablyFile` / `expectsFile` evaluated to `false`, silently falling back to treating the unreadable file path as a raw string literal (`"@subfolder\\\\unreadablefile"`) instead of surfacing a file read error.

### Root Cause
`probablyFile` and `expectsFile` checks in `pkg/cmd/flagoptions.go` (lines 237 and 265) checked for `.` and `/` (`strings.Contains(filename, ".") || strings.Contains(filename, "/")`), but omitted `\\` (`strings.Contains(filename, "\\\\")`).

### Implementation
Updated path detection in `embedFilesValue` (`pkg/cmd/flagoptions.go`) to also check for `\\` (`strings.Contains(filename, "\\\\")`), ensuring paths using backslashes are recognized as file references when handling unreadable file errors.

### Regression Coverage
Added unit test case `"non-existent file with backslash path @ prefix (error)"` in `pkg/cmd/flagoptions_test.go` to assert that unreadable backslash path references properly return a file reading error instead of falling back to a raw string literal.

### Exact Validation Commands & Results
- `go test ./pkg/cmd -run TestEmbedFiles` -> Passed
- `go test ./internal/...` -> Passed
- `go vet ./internal/... ./pkg/...` -> Passed (clean)
- `git diff --check` -> Passed (clean)

### Limitations or Untested Platforms
None.

### Unrelated Changes
No unrelated changes were included.