### PR TITLE
ci: grant CodeQL Actions read access

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      actions: read
       contents: read
       security-events: write
     strategy:


### PR DESCRIPTION
## Summary

- grant the CodeQL job read access to Actions workflow metadata
- prevent CodeQL post-processing from failing when it queries the workflow run

## Validation

The identical isolated change passed both CodeQL matrices and the full CI suite in `openai/openai-cli-internal#10`.