### PR TITLE
feat: Add mutual TLS client certificate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ openai files list
 Both mTLS files must be configured together. Keep the private key in a
 permission-restricted file; do not put private-key contents directly in command
 arguments or environment variables. The CLI does not automatically select an
-mTLS endpoint, so configure `OPENAI_BASE_URL` or `--base-url` explicitly.
+mTLS endpoint, so configure `OPENAI_BASE_URL` or `--base-url` explicitly. HTTP
+and SOCKS proxies remain supported, but HTTPS proxies are rejected to prevent
+presenting the client certificate during the proxy's own TLS handshake.
 
 ### Passing files as arguments
 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,15 @@ For details about specific commands, use the `--help` flag.
 
 ### Environment variables
 
-| Environment variable    | Required | Default value |
-| ----------------------- | -------- | ------------- |
-| `OPENAI_API_KEY`        | no       | `null`        |
-| `OPENAI_ADMIN_KEY`      | no       | `null`        |
-| `OPENAI_ORG_ID`         | no       | `null`        |
-| `OPENAI_PROJECT_ID`     | no       | `null`        |
-| `OPENAI_WEBHOOK_SECRET` | no       | `null`        |
+| Environment variable | Required | Default value |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | no | `null` |
+| `OPENAI_ADMIN_KEY` | no | `null` |
+| `OPENAI_ORG_ID` | no | `null` |
+| `OPENAI_PROJECT_ID` | no | `null` |
+| `OPENAI_WEBHOOK_SECRET` | no | `null` |
+| `OPENAI_MTLS_CLIENT_CERT_FILE` | no | `null` |
+| `OPENAI_MTLS_CLIENT_KEY_FILE` | no | `null` |
 
 ### Global flags
 
@@ -91,6 +93,8 @@ For details about specific commands, use the `--help` flag.
 - `--organization` (can also be set with `OPENAI_ORG_ID` env var)
 - `--project` (can also be set with `OPENAI_PROJECT_ID` env var)
 - `--webhook-secret` (can also be set with `OPENAI_WEBHOOK_SECRET` env var)
+- `--mtls-client-cert-file` (can also be set with `OPENAI_MTLS_CLIENT_CERT_FILE` env var)
+- `--mtls-client-key-file` (can also be set with `OPENAI_MTLS_CLIENT_KEY_FILE` env var)
 - `--help` - Show command line usage
 - `--debug` - Enable debug logging. This includes HTTP request/response details and bodies; do not share debug logs if they may contain sensitive payloads.
 - `--version`, `-v` - Show the CLI version
@@ -99,6 +103,33 @@ For details about specific commands, use the `--help` flag.
 - `--format-error` - Change the output format for errors (`auto`, `explore`, `json`, `jsonl`, `pretty`, `raw`, `yaml`)
 - `--transform` - Transform the data output using [GJSON syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md)
 - `--transform-error` - Transform the error output using [GJSON syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md)
+
+### Mutual TLS
+
+Mutual TLS is currently in beta. To opt in and activate a CA certificate for
+your organization or project, follow the
+[OpenAI Mutual TLS Beta Program](https://help.openai.com/en/articles/10876024-openai-mutual-tls-beta-program)
+instructions.
+
+To authenticate API-key requests with a mutual TLS client certificate, provide
+the client certificate and private key as separate PEM files. If certificate
+chain support is enabled for your organization, the certificate file must
+contain the leaf certificate first, followed by any intermediate certificates.
+Otherwise, use a client certificate signed directly by an activated CA
+certificate.
+
+```sh
+export OPENAI_MTLS_CLIENT_CERT_FILE=/run/secrets/openai/client-chain.pem
+export OPENAI_MTLS_CLIENT_KEY_FILE=/run/secrets/openai/client.key
+export OPENAI_BASE_URL=https://mtls.api.openai.com/v1
+
+openai files list
+```
+
+Both mTLS files must be configured together. Keep the private key in a
+permission-restricted file; do not put private-key contents directly in command
+arguments or environment variables. The CLI does not automatically select an
+mTLS endpoint, so configure `OPENAI_BASE_URL` or `--base-url` explicitly.
 
 ### Passing files as arguments
 

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -30,7 +30,8 @@ func init() {
 		Suggest:   true,
 		Version:   Version,
 		ErrWriter: &CommandErrorBuffer,
-		Flags: []cli.Flag{
+		Before:    configureMTLS,
+		Flags: append([]cli.Flag{
 			&cli.BoolFlag{
 				Name:  "debug",
 				Usage: "Enable debug logging",
@@ -98,7 +99,7 @@ func init() {
 				Name:    "webhook-secret",
 				Sources: cli.EnvVars("OPENAI_WEBHOOK_SECRET"),
 			},
-		},
+		}, mtlsClientFlags()...),
 		Commands: []*cli.Command{
 			{
 				Name:     "completions",

--- a/pkg/cmd/cmdutil.go
+++ b/pkg/cmd/cmdutil.go
@@ -64,6 +64,9 @@ func getDefaultRequestOptions(cmd *cli.Command) []option.RequestOption {
 	if baseURL := cmd.String("base-url"); baseURL != "" {
 		opts = append(opts, option.WithBaseURL(baseURL))
 	}
+	if httpClient, ok := cmd.Root().Metadata[mtlsHTTPClientMetadata].(*http.Client); ok {
+		opts = append(opts, option.WithHTTPClient(httpClient))
+	}
 
 	return opts
 }

--- a/pkg/cmd/mtls.go
+++ b/pkg/cmd/mtls.go
@@ -141,8 +141,7 @@ func newMTLSHTTPClient(certFile, keyFile, baseURL string) (*http.Client, error) 
 	return &http.Client{
 		Transport: transport,
 		CheckRedirect: func(request *http.Request, via []*http.Request) error {
-			if !strings.EqualFold(request.URL.Scheme, endpoint.Scheme) ||
-				!strings.EqualFold(request.URL.Host, endpoint.Host) {
+			if !sameURLOrigin(request.URL, endpoint) {
 				return http.ErrUseLastResponse
 			}
 			if len(via) >= 10 {
@@ -151,6 +150,25 @@ func newMTLSHTTPClient(certFile, keyFile, baseURL string) (*http.Client, error) 
 			return nil
 		},
 	}, nil
+}
+
+func sameURLOrigin(left, right *url.URL) bool {
+	return strings.EqualFold(left.Scheme, right.Scheme) &&
+		strings.EqualFold(left.Hostname(), right.Hostname()) &&
+		effectiveURLPort(left) == effectiveURLPort(right)
+}
+
+func effectiveURLPort(parsedURL *url.URL) string {
+	if port := parsedURL.Port(); port != "" {
+		return port
+	}
+	if strings.EqualFold(parsedURL.Scheme, "https") {
+		return "443"
+	}
+	if strings.EqualFold(parsedURL.Scheme, "http") {
+		return "80"
+	}
+	return ""
 }
 
 func readMTLSFile(kind, path string) ([]byte, error) {

--- a/pkg/cmd/mtls.go
+++ b/pkg/cmd/mtls.go
@@ -46,6 +46,10 @@ func mtlsClientFlags() []cli.Flag {
 }
 
 func configureMTLS(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+	if cmd.Metadata == nil {
+		cmd.Metadata = map[string]any{}
+	}
+
 	certFile, _ := cmd.Value(mtlsClientCertFileFlag).(string)
 	keyFile, _ := cmd.Value(mtlsClientKeyFileFlag).(string)
 	baseURL := cmd.String("base-url")

--- a/pkg/cmd/mtls.go
+++ b/pkg/cmd/mtls.go
@@ -111,6 +111,19 @@ func newMTLSHTTPClient(certFile, keyFile, baseURL string) (*http.Client, error) 
 
 	transport := baseTransport.Clone()
 	transport.ResponseHeaderTimeout = openAISDKResponseHeaderTimeout
+	if proxy := transport.Proxy; proxy != nil {
+		transport.Proxy = func(request *http.Request) (*url.URL, error) {
+			proxyURL, err := proxy(request)
+			if err != nil || proxyURL == nil {
+				return proxyURL, err
+			}
+			if strings.EqualFold(proxyURL.Scheme, "https") {
+				return nil, errors.New("mTLS does not support HTTPS proxies")
+			}
+			return proxyURL, nil
+		}
+	}
+
 	tlsConfig := transport.TLSClientConfig
 	if tlsConfig == nil {
 		tlsConfig = &tls.Config{}

--- a/pkg/cmd/mtls.go
+++ b/pkg/cmd/mtls.go
@@ -1,0 +1,153 @@
+package cmd
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/urfave/cli/v3"
+)
+
+const (
+	mtlsClientCertFileFlag = "mtls-client-cert-file"
+	mtlsClientCertFileEnv  = "OPENAI_MTLS_CLIENT_CERT_FILE"
+	mtlsClientKeyFileFlag  = "mtls-client-key-file"
+	mtlsClientKeyFileEnv   = "OPENAI_MTLS_CLIENT_KEY_FILE"
+	mtlsHTTPClientMetadata = "mtls-http-client"
+
+	// Supplying a custom HTTP client bypasses openai-go's default transport
+	// construction, so preserve its response-header timeout here.
+	openAISDKResponseHeaderTimeout = 10 * time.Minute
+)
+
+func mtlsClientFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:      mtlsClientCertFileFlag,
+			Usage:     "Path to a PEM client certificate chain for mutual TLS (leaf first, followed by intermediates)",
+			Sources:   cli.EnvVars(mtlsClientCertFileEnv),
+			TakesFile: true,
+			OnlyOnce:  true,
+		},
+		&cli.StringFlag{
+			Name:      mtlsClientKeyFileFlag,
+			Usage:     "Path to the PEM private key for the mutual TLS client certificate",
+			Sources:   cli.EnvVars(mtlsClientKeyFileEnv),
+			TakesFile: true,
+			OnlyOnce:  true,
+		},
+	}
+}
+
+func configureMTLS(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+	certFile, _ := cmd.Value(mtlsClientCertFileFlag).(string)
+	keyFile, _ := cmd.Value(mtlsClientKeyFileFlag).(string)
+	baseURL := cmd.String("base-url")
+	if baseURL == "" {
+		baseURL = os.Getenv("OPENAI_BASE_URL")
+	}
+
+	client, err := newMTLSHTTPClient(
+		certFile,
+		keyFile,
+		baseURL,
+	)
+	if err != nil {
+		delete(cmd.Metadata, mtlsHTTPClientMetadata)
+		return ctx, err
+	}
+
+	if client == nil {
+		delete(cmd.Metadata, mtlsHTTPClientMetadata)
+	} else {
+		cmd.Metadata[mtlsHTTPClientMetadata] = client
+	}
+	return ctx, nil
+}
+
+func newMTLSHTTPClient(certFile, keyFile, baseURL string) (*http.Client, error) {
+	if certFile == "" && keyFile == "" {
+		return nil, nil
+	}
+	if certFile == "" || keyFile == "" {
+		return nil, errors.New("mTLS client certificate and key files must be configured together")
+	}
+	endpoint, err := url.Parse(baseURL)
+	if err != nil || !strings.EqualFold(endpoint.Scheme, "https") || endpoint.Host == "" {
+		return nil, errors.New("mTLS requires an explicit HTTPS base URL")
+	}
+
+	certPEM, err := readMTLSFile("certificate", certFile)
+	if err != nil {
+		return nil, err
+	}
+	defer clear(certPEM)
+
+	keyPEM, err := readMTLSFile("key", keyFile)
+	if err != nil {
+		return nil, err
+	}
+	defer clear(keyPEM)
+
+	certificate, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, errors.New("mTLS client certificate and key must be a valid matching PEM pair")
+	}
+
+	baseTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, errors.New("mTLS requires the default HTTP transport to be an *http.Transport")
+	}
+
+	transport := baseTransport.Clone()
+	transport.ResponseHeaderTimeout = openAISDKResponseHeaderTimeout
+	tlsConfig := transport.TLSClientConfig
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	} else {
+		tlsConfig = tlsConfig.Clone()
+	}
+	// The user explicitly selected this pair, so present it whenever the endpoint
+	// requests client authentication instead of filtering it against the server's
+	// advertised CA names.
+	tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		return &certificate, nil
+	}
+	transport.TLSClientConfig = tlsConfig
+
+	return &http.Client{
+		Transport: transport,
+		CheckRedirect: func(request *http.Request, via []*http.Request) error {
+			if !strings.EqualFold(request.URL.Scheme, endpoint.Scheme) ||
+				!strings.EqualFold(request.URL.Host, endpoint.Host) {
+				return http.ErrUseLastResponse
+			}
+			if len(via) >= 10 {
+				return errors.New("stopped after 10 redirects")
+			}
+			return nil
+		},
+	}, nil
+}
+
+func readMTLSFile(kind, path string) ([]byte, error) {
+	contents, err := os.ReadFile(path)
+	if err == nil {
+		return contents, nil
+	}
+
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return nil, errors.New("mTLS client " + kind + " file does not exist")
+	case errors.Is(err, fs.ErrPermission):
+		return nil, errors.New("mTLS client " + kind + " file is not readable")
+	default:
+		return nil, errors.New("could not read mTLS client " + kind + " file")
+	}
+}

--- a/pkg/cmd/mtls_test.go
+++ b/pkg/cmd/mtls_test.go
@@ -1,0 +1,483 @@
+package cmd
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"log"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+func TestMTLSClientFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		envName string
+	}{
+		{name: mtlsClientCertFileFlag, envName: mtlsClientCertFileEnv},
+		{name: mtlsClientKeyFileFlag, envName: mtlsClientKeyFileEnv},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			flag := findCommandFlag(t, tt.name)
+			stringFlag, ok := flag.(*cli.StringFlag)
+			require.True(t, ok)
+			assert.True(t, stringFlag.TakesFile)
+			assert.Equal(t, []string{tt.envName}, stringFlag.GetEnvVars())
+		})
+	}
+}
+
+func TestNewMTLSHTTPClient(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		t.Parallel()
+
+		client, err := newMTLSHTTPClient("", "", "")
+		require.NoError(t, err)
+		assert.Nil(t, client)
+	})
+
+	t.Run("requires certificate and key together", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := newMTLSHTTPClient("certificate.pem", "", "")
+		require.EqualError(t, err, "mTLS client certificate and key files must be configured together")
+
+		_, err = newMTLSHTTPClient("", "key.pem", "")
+		require.EqualError(t, err, "mTLS client certificate and key files must be configured together")
+	})
+
+	t.Run("requires an explicit HTTPS base URL", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := newMTLSHTTPClient("certificate.pem", "key.pem", "")
+		require.EqualError(t, err, "mTLS requires an explicit HTTPS base URL")
+
+		_, err = newMTLSHTTPClient("certificate.pem", "key.pem", "http://api.example.test")
+		require.EqualError(t, err, "mTLS requires an explicit HTTPS base URL")
+
+		_, err = newMTLSHTTPClient("certificate.pem", "key.pem", "https:///v1")
+		require.EqualError(t, err, "mTLS requires an explicit HTTPS base URL")
+	})
+
+	t.Run("does not expose supplied values in file errors", func(t *testing.T) {
+		t.Parallel()
+
+		inlineCertificate := "-----BEGIN CERTIFICATE-----\nsensitive-certificate-value\n-----END CERTIFICATE-----"
+		_, err := newMTLSHTTPClient(inlineCertificate, "key.pem", "https://api.example.test")
+		require.EqualError(t, err, "mTLS client certificate file does not exist")
+		assert.NotContains(t, err.Error(), inlineCertificate)
+
+		certFile := filepath.Join(t.TempDir(), "certificate.pem")
+		require.NoError(t, os.WriteFile(certFile, []byte("not a certificate"), 0o600))
+		inlineKey := "-----BEGIN PRIVATE KEY-----\nsensitive-private-key-value\n-----END PRIVATE KEY-----"
+		_, err = newMTLSHTTPClient(certFile, inlineKey, "https://api.example.test")
+		require.EqualError(t, err, "mTLS client key file does not exist")
+		assert.NotContains(t, err.Error(), inlineKey)
+	})
+
+	t.Run("rejects an invalid pair without exposing contents", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		certFile := filepath.Join(dir, "certificate.pem")
+		keyFile := filepath.Join(dir, "key.pem")
+		certContents := "sensitive invalid certificate"
+		keyContents := "sensitive invalid private key"
+		require.NoError(t, os.WriteFile(certFile, []byte(certContents), 0o600))
+		require.NoError(t, os.WriteFile(keyFile, []byte(keyContents), 0o600))
+
+		_, err := newMTLSHTTPClient(certFile, keyFile, "https://api.example.test")
+		require.EqualError(t, err, "mTLS client certificate and key must be a valid matching PEM pair")
+		assert.NotContains(t, err.Error(), certContents)
+		assert.NotContains(t, err.Error(), keyContents)
+	})
+}
+
+func TestNewMTLSHTTPClientPreservesDefaultTransport(t *testing.T) {
+	pki := newMTLSTestPKI(t)
+	certFile, keyFile := writeMTLSClientFiles(t, pki.clientChainPEM, pki.clientKeyPEM)
+
+	proxyURL, err := url.Parse("http://proxy.example.test:8443")
+	require.NoError(t, err)
+	rootPool := x509.NewCertPool()
+	require.True(t, rootPool.AppendCertsFromPEM(pki.rootPEM))
+	baseTransport := &http.Transport{
+		Proxy: func(*http.Request) (*url.URL, error) {
+			return proxyURL, nil
+		},
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS13,
+			RootCAs:    rootPool,
+			ServerName: "api.example.test",
+		},
+	}
+
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = baseTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	client, err := newMTLSHTTPClient(certFile, keyFile, "https://api.example.test")
+	require.NoError(t, err)
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+
+	assert.NotSame(t, baseTransport, transport)
+	assert.NotSame(t, baseTransport.TLSClientConfig, transport.TLSClientConfig)
+	assert.Empty(t, baseTransport.TLSClientConfig.Certificates)
+	assert.Empty(t, transport.TLSClientConfig.Certificates)
+	require.NotNil(t, transport.TLSClientConfig.GetClientCertificate)
+	selectedCertificate, err := transport.TLSClientConfig.GetClientCertificate(&tls.CertificateRequestInfo{})
+	require.NoError(t, err)
+	assert.Len(t, selectedCertificate.Certificate, 2)
+	assert.Same(t, rootPool, transport.TLSClientConfig.RootCAs)
+	assert.Equal(t, uint16(tls.VersionTLS13), transport.TLSClientConfig.MinVersion)
+	assert.Equal(t, "api.example.test", transport.TLSClientConfig.ServerName)
+	assert.Equal(t, openAISDKResponseHeaderTimeout, transport.ResponseHeaderTimeout)
+
+	request, err := http.NewRequest(http.MethodGet, "https://api.example.test", nil)
+	require.NoError(t, err)
+	actualProxyURL, err := transport.Proxy(request)
+	require.NoError(t, err)
+	assert.Equal(t, proxyURL, actualProxyURL)
+
+	sameOriginRedirect, err := http.NewRequest(http.MethodGet, "https://api.example.test/redirected", nil)
+	require.NoError(t, err)
+	require.NoError(t, client.CheckRedirect(sameOriginRedirect, []*http.Request{request}))
+
+	crossOriginRedirect, err := http.NewRequest(http.MethodGet, "https://other.example.test", nil)
+	require.NoError(t, err)
+	assert.ErrorIs(t, client.CheckRedirect(crossOriginRedirect, []*http.Request{request}), http.ErrUseLastResponse)
+}
+
+func TestCLIUsesMTLSClientCertificateChain(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-api-key")
+	pki := newMTLSTestPKI(t)
+	clientCAs := x509.NewCertPool()
+	require.True(t, clientCAs.AppendCertsFromPEM(pki.rootPEM))
+
+	type requestDetails struct {
+		authorization string
+		chainLength   int
+	}
+	requests := make(chan requestDetails, 1)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chainLength := 0
+		if r.TLS != nil && len(r.TLS.VerifiedChains) > 0 {
+			chainLength = len(r.TLS.VerifiedChains[0])
+		}
+		requests <- requestDetails{
+			authorization: r.Header.Get("Authorization"),
+			chainLength:   chainLength,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"object":"list","data":[]}`)
+	}))
+	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	server.TLS = &tls.Config{
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  clientCAs,
+		MinVersion: tls.VersionTLS12,
+	}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	configureTestServerTrust(t, server)
+
+	certFile, keyFile := writeMTLSClientFiles(t, pki.clientChainPEM, pki.clientKeyPEM)
+	require.NoError(t, runMTLSTestCommand(t, server.URL, certFile, keyFile))
+
+	select {
+	case request := <-requests:
+		assert.Equal(t, "Bearer test-api-key", request.authorization)
+		assert.Equal(t, 3, request.chainLength)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the CLI request")
+	}
+}
+
+func TestCLIUsesMTLSClientCertificateWithUnrecognizedCAHint(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-api-key")
+	pki := newMTLSTestPKI(t)
+
+	requests := make(chan int, 1)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peerCertificateCount := 0
+		if r.TLS != nil {
+			peerCertificateCount = len(r.TLS.PeerCertificates)
+		}
+		requests <- peerCertificateCount
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"object":"list","data":[]}`)
+	}))
+	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	server.TLS = &tls.Config{
+		ClientAuth: tls.RequireAnyClientCert,
+		MinVersion: tls.VersionTLS12,
+	}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	// Advertise an unrelated acceptable CA name, as some mTLS endpoints do.
+	// The explicitly configured certificate must still be presented.
+	clientCAs := x509.NewCertPool()
+	clientCAs.AddCert(server.Certificate())
+	server.TLS.ClientCAs = clientCAs
+	configureTestServerTrust(t, server)
+
+	certFile, keyFile := writeMTLSClientFiles(t, pki.clientChainPEM, pki.clientKeyPEM)
+	require.NoError(t, runMTLSTestCommand(t, server.URL, certFile, keyFile))
+
+	select {
+	case peerCertificateCount := <-requests:
+		assert.Equal(t, 2, peerCertificateCount)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the CLI request")
+	}
+}
+
+func TestCLIUsesMTLSFilesFromEnvironment(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-api-key")
+	pki := newMTLSTestPKI(t)
+	clientCAs := x509.NewCertPool()
+	require.True(t, clientCAs.AppendCertsFromPEM(pki.rootPEM))
+
+	requests := make(chan int, 1)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peerCertificateCount := 0
+		if r.TLS != nil {
+			peerCertificateCount = len(r.TLS.PeerCertificates)
+		}
+		requests <- peerCertificateCount
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"object":"list","data":[]}`)
+	}))
+	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	server.TLS = &tls.Config{
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  clientCAs,
+		MinVersion: tls.VersionTLS12,
+	}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	configureTestServerTrust(t, server)
+
+	certFile, keyFile := writeMTLSClientFiles(t, pki.clientChainPEM, pki.clientKeyPEM)
+	t.Setenv(mtlsClientCertFileEnv, certFile)
+	t.Setenv(mtlsClientKeyFileEnv, keyFile)
+	require.NoError(t, runMTLSTestCommandWithArgs(t, server.URL))
+
+	select {
+	case peerCertificateCount := <-requests:
+		assert.Equal(t, 2, peerCertificateCount)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the CLI request")
+	}
+}
+
+func TestCLIRejectsIncompleteMTLSClientChain(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-api-key")
+	pki := newMTLSTestPKI(t)
+	clientCAs := x509.NewCertPool()
+	require.True(t, clientCAs.AppendCertsFromPEM(pki.rootPEM))
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("server handler must not run when the client certificate chain cannot be verified")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	server.Config.ErrorLog = log.New(io.Discard, "", 0)
+	server.TLS = &tls.Config{
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  clientCAs,
+		MinVersion: tls.VersionTLS12,
+	}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	configureTestServerTrust(t, server)
+
+	certFile, keyFile := writeMTLSClientFiles(t, pki.clientLeafPEM, pki.clientKeyPEM)
+	require.Error(t, runMTLSTestCommand(t, server.URL, certFile, keyFile))
+}
+
+func findCommandFlag(t *testing.T, name string) cli.Flag {
+	t.Helper()
+
+	for _, flag := range Command.Flags {
+		if flag.Names()[0] == name {
+			return flag
+		}
+	}
+
+	t.Fatalf("flag %q was not found", name)
+	return nil
+}
+
+func runMTLSTestCommand(t *testing.T, baseURL, certFile, keyFile string) error {
+	t.Helper()
+
+	return runMTLSTestCommandWithArgs(
+		t,
+		baseURL,
+		"--mtls-client-cert-file", certFile,
+		"--mtls-client-key-file", keyFile,
+	)
+}
+
+func runMTLSTestCommandWithArgs(t *testing.T, baseURL string, args ...string) error {
+	t.Helper()
+
+	command := &cli.Command{
+		Name:   "openai-test",
+		Before: configureMTLS,
+		Flags: append([]cli.Flag{
+			&cli.StringFlag{Name: "base-url"},
+		}, mtlsClientFlags()...),
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			client := openai.NewClient(getDefaultRequestOptions(cmd)...)
+			_, err := client.Models.List(ctx)
+			return err
+		},
+	}
+	commandArgs := append(
+		[]string{command.Name, "--base-url", baseURL},
+		args...,
+	)
+	return command.Run(context.Background(), commandArgs)
+}
+
+func configureTestServerTrust(t *testing.T, server *httptest.Server) {
+	t.Helper()
+
+	serverRoots := x509.NewCertPool()
+	serverRoots.AddCert(server.Certificate())
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: serverRoots},
+	}
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+}
+
+type mtlsTestPKI struct {
+	rootPEM        []byte
+	clientLeafPEM  []byte
+	clientChainPEM []byte
+	clientKeyPEM   []byte
+}
+
+func newMTLSTestPKI(t *testing.T) mtlsTestPKI {
+	t.Helper()
+
+	now := time.Now()
+	rootTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "mTLS test root"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	rootDER, rootCertificate, rootKey := createTestCertificate(t, rootTemplate, rootTemplate, nil)
+
+	intermediateTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "mTLS test intermediate"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            0,
+		MaxPathLenZero:        true,
+	}
+	intermediateDER, intermediateCertificate, intermediateKey := createTestCertificate(
+		t,
+		intermediateTemplate,
+		rootCertificate,
+		rootKey,
+	)
+
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "mTLS test client"},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER, _, clientKey := createTestCertificate(
+		t,
+		clientTemplate,
+		intermediateCertificate,
+		intermediateKey,
+	)
+
+	clientKeyDER, err := x509.MarshalECPrivateKey(clientKey)
+	require.NoError(t, err)
+	clientLeafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
+	intermediatePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: intermediateDER})
+
+	return mtlsTestPKI{
+		rootPEM:        pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER}),
+		clientLeafPEM:  clientLeafPEM,
+		clientChainPEM: append(clientLeafPEM, intermediatePEM...),
+		clientKeyPEM:   pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: clientKeyDER}),
+	}
+}
+
+func createTestCertificate(
+	t *testing.T,
+	template *x509.Certificate,
+	parent *x509.Certificate,
+	parentKey *ecdsa.PrivateKey,
+) ([]byte, *x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	if parentKey == nil {
+		parentKey = key
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, parent, &key.PublicKey, parentKey)
+	require.NoError(t, err)
+	certificate, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return der, certificate, key
+}
+
+func writeMTLSClientFiles(t *testing.T, certPEM, keyPEM []byte) (string, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "client-chain.pem")
+	keyFile := filepath.Join(dir, "client-key.pem")
+	require.NoError(t, os.WriteFile(certFile, certPEM, 0o600))
+	require.NoError(t, os.WriteFile(keyFile, keyPEM, 0o600))
+	return certFile, keyFile
+}

--- a/pkg/cmd/mtls_test.go
+++ b/pkg/cmd/mtls_test.go
@@ -179,10 +179,16 @@ func TestNewMTLSHTTPClientPreservesDefaultTransport(t *testing.T) {
 	sameOriginRedirect, err := http.NewRequest(http.MethodGet, "https://api.example.test/redirected", nil)
 	require.NoError(t, err)
 	require.NoError(t, client.CheckRedirect(sameOriginRedirect, []*http.Request{request}))
+	sameOriginDefaultPortRedirect, err := http.NewRequest(http.MethodGet, "https://API.example.test:443/redirected", nil)
+	require.NoError(t, err)
+	require.NoError(t, client.CheckRedirect(sameOriginDefaultPortRedirect, []*http.Request{request}))
 
 	crossOriginRedirect, err := http.NewRequest(http.MethodGet, "https://other.example.test", nil)
 	require.NoError(t, err)
 	assert.ErrorIs(t, client.CheckRedirect(crossOriginRedirect, []*http.Request{request}), http.ErrUseLastResponse)
+	crossOriginPortRedirect, err := http.NewRequest(http.MethodGet, "https://api.example.test:8443", nil)
+	require.NoError(t, err)
+	assert.ErrorIs(t, client.CheckRedirect(crossOriginPortRedirect, []*http.Request{request}), http.ErrUseLastResponse)
 }
 
 func TestCLIUsesMTLSClientCertificateChain(t *testing.T) {

--- a/pkg/cmd/mtls_test.go
+++ b/pkg/cmd/mtls_test.go
@@ -122,10 +122,15 @@ func TestNewMTLSHTTPClientPreservesDefaultTransport(t *testing.T) {
 
 	proxyURL, err := url.Parse("http://proxy.example.test:8443")
 	require.NoError(t, err)
+	httpsProxyURL, err := url.Parse("https://proxy.example.test:8443")
+	require.NoError(t, err)
 	rootPool := x509.NewCertPool()
 	require.True(t, rootPool.AppendCertsFromPEM(pki.rootPEM))
 	baseTransport := &http.Transport{
-		Proxy: func(*http.Request) (*url.URL, error) {
+		Proxy: func(request *http.Request) (*url.URL, error) {
+			if request.URL.Host == "https-proxy-target.example.test" {
+				return httpsProxyURL, nil
+			}
 			return proxyURL, nil
 		},
 		TLSClientConfig: &tls.Config{
@@ -164,6 +169,12 @@ func TestNewMTLSHTTPClientPreservesDefaultTransport(t *testing.T) {
 	actualProxyURL, err := transport.Proxy(request)
 	require.NoError(t, err)
 	assert.Equal(t, proxyURL, actualProxyURL)
+
+	httpsProxyRequest, err := http.NewRequest(http.MethodGet, "https://https-proxy-target.example.test", nil)
+	require.NoError(t, err)
+	actualProxyURL, err = transport.Proxy(httpsProxyRequest)
+	require.EqualError(t, err, "mTLS does not support HTTPS proxies")
+	assert.Nil(t, actualProxyURL)
 
 	sameOriginRedirect, err := http.NewRequest(http.MethodGet, "https://api.example.test/redirected", nil)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- add `--mtls-client-cert-file` and `--mtls-client-key-file`, with environment-variable equivalents, for API-key requests
- build a command-scoped Go HTTP transport that presents the selected certificate chain while preserving existing proxy and TLS settings
- require an explicit HTTPS base URL and prevent cross-origin redirects from presenting the client certificate
- document beta enrollment, certificate-chain behavior, safe private-key handling, and endpoint configuration

## Why

CLI users in the OpenAI Mutual TLS Beta Program need a safe file-based way to compose API-key authentication with HTTP mTLS. Go's default certificate selection can decline an explicitly configured certificate when the endpoint advertises unrelated CA hints, so the transport returns the selected pair through `GetClientCertificate` whenever the configured endpoint requests client authentication.

## Validation

- `./scripts/test` (including Windows compile check)
- `go test -race ./pkg/cmd -run 'Test(NewMTLSHTTPClient|CLIUsesMTLS)' -count=1`
- `go vet ./...`
- `./scripts/lint`
- live mTLS smoke test against `https://mtls.api.openai.com/v1/files` with the enrolled direct certificate fixture
- live mTLS smoke test with the enrolled leaf-plus-intermediate chain fixture
- thermo-nuclear and multi-axis code-quality reviews