### PR TITLE
fix(output): stop pagination at max items

### DIFF
--- a/pkg/cmd/cmdutil.go
+++ b/pkg/cmd/cmdutil.go
@@ -551,10 +551,7 @@ func ShowJSONIterator[T any](iter jsonview.Iterator[T], itemsToDisplay int64, op
 		pagerOpts := opts
 		pagerOpts.Stdout = pager
 
-		for iter.Next() {
-			if itemsToDisplay == 0 {
-				break
-			}
+		for itemsToDisplay != 0 && iter.Next() {
 			item := iter.Current()
 			var obj gjson.Result
 			if hasRaw, ok := any(item).(hasRawJSON); ok {

--- a/pkg/cmd/cmdutil_test.go
+++ b/pkg/cmd/cmdutil_test.go
@@ -424,6 +424,29 @@ func TestShowJSONIterator(t *testing.T) {
 	})
 }
 
+func TestShowJSONIteratorLimitDoesNotAdvancePager(t *testing.T) {
+	stdout, err := os.CreateTemp(t.TempDir(), "stdout")
+	require.NoError(t, err)
+	defer stdout.Close()
+
+	originalStdout := os.Stdout
+	os.Stdout = stdout
+	defer func() { os.Stdout = originalStdout }()
+
+	iter := &sliceIterator[map[string]any]{items: []map[string]any{
+		{"value": make([]int, 40)},
+		{"id": "not-visited"},
+	}}
+	err = ShowJSONIterator(iter, 1, ShowJSONOpts{
+		Format: "pretty",
+		Stderr: io.Discard,
+		Stdout: stdout,
+		Title:  "test",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, iter.index)
+}
+
 func TestExploreFallback(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- check the remaining item limit before advancing a paged iterator
- avoid fetching or consuming one extra item after `--max-items` is reached
- cover the pager path with a regression test

## Testing

- `go test ./pkg/cmd -run TestShowJSONIterator -count=1`
- `go test ./internal/...`