### PR TITLE
ci: prepare checks for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches-ignore:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
+  merge_group:
+    types:
+      - checks_requested
 
 env:
   GOPRIVATE: github.com/openai/openai-go/v3,github.com/stainless-sdks/openai-go/v3


### PR DESCRIPTION
## Summary

- run the existing CI workflow for `merge_group: checks_requested`
- keep all existing pull-request, `main` push, Stainless, and release behavior unchanged
- leave merge queue disabled until this prerequisite lands

## Why

The `main` ruleset requires the GitHub Actions contexts `build`, `lint`, and `test`. GitHub's merge queue evaluates a synthetic merge-group commit, so the workflow must subscribe to `merge_group` before the queue is enabled or queued pull requests would wait for checks that never start.

The workflow's ordinary push trigger is already limited to `main`, so `gh-readonly-queue/**` pushes cannot create a duplicate or cancellation-prone run and no push exclusion is needed.

## Validation

- `git diff --check origin/main...HEAD`
- workflow YAML parse
- required-context/job-gate audit for `build`, `lint`, and `test`
- thermo-nuclear code-quality review