### PR TITLE
ci: use shared SDK app for Release Please

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -11,7 +11,7 @@ jobs:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-cli'
     runs-on: ubuntu-latest
-    environment: publish
+    environment: release
     permissions: {}
 
     steps:

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -17,11 +17,12 @@ jobs:
     steps:
       - name: Create release app token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.OPENAI_SDKS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.OPENAI_SDKS_APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-issues: write
           permission-pull-requests: write
 
       - name: Run release-please

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -57,14 +57,14 @@ jobs:
         go-version-file: "go.mod"
     - name: Create release app token for this repo
       id: app-token
-      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         app-id: ${{ secrets.RELEASE_APP_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
         permission-contents: write
     - name: Create release app token for homebrew-tools
       id: tap-token
-      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         app-id: ${{ secrets.RELEASE_APP_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- mint a repository-scoped installation token for the shared `openai-sdks` GitHub App when Release Please runs
- isolate Release Please credentials in a dedicated `release` environment
- keep the `openai-homebrew-releaser` App and macOS signing/notarization credentials in `publish`
- update every `actions/create-github-app-token` use to the verified v3.2.0 commit

## Why

Release Please should use the same dedicated SDK automation identity as the other OpenAI SDK repositories. Separating `release` from `publish` keeps release-PR and tag orchestration isolated from the credential that can also write to `openai/homebrew-tools` and from artifact-signing credentials.

The installation token is limited to this repository and requests only contents, issues, and pull-request write permissions. App-authored pushes and pull-request updates continue to trigger the normal downstream workflows.

## Repository configuration

- [x] create an unreviewed `release` environment restricted to `main`
- [x] add `OPENAI_SDKS_APP_CLIENT_ID=Iv23li2AtcmhLHO07J87` to `release`
- [x] add `OPENAI_SDKS_APP_PRIVATE_KEY` to `release`
- [x] allow the `openai-sdks` App (App ID `3705508`) to bypass the `release-please branches` ruleset
- [x] allow the `openai-sdks` App to create protected `v*` tags in the `Release tags` ruleset

The environment, branch policy, variable, secret name, and both ruleset grants were verified through the GitHub API. GitHub secrets are write-only, so the private-key value itself is not readable after creation.

The existing Homebrew App credentials and macOS signing/notarization secrets remain in `publish`, where `publish-release.yml` uses them for GitHub release artifacts and `openai/homebrew-tools`.

## Validation

- `./scripts/lint`
- `./scripts/test`, including Windows compilation
- `actionlint` v1.7.7 across all workflows
- `git diff --check`
- thermo-nuclear code quality review
