### PR TITLE
fix(api): clarify audio upload metadata requirements

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: d212ddc6-7cb0-4a0a-9ba7-51c6b50833cf
-openapi_spec_hash: 8d5c14d02f8cc28de343933fae3a9c28
-openapi_transformed_spec_hash: cc042503b90491f4f162ce95fae87c36
+generation_id: f0ec9f15-8fa4-4a49-96c0-310ff2f5ecde
+openapi_spec_hash: 1faf0319c407c6534ef7c381614afbb6
+openapi_transformed_spec_hash: 53eff50caa9d18046e4ff0615bc7512d
 config_hash: 4617b0962f16d328804312ac81aac630
-codegen_sha: f23b6be4c9ef84a3d262d5a5136b390e53ee3b19
+codegen_sha: c767a02c75de20f85dfcddb2ce03e5a78cb5beb0

--- a/api_reference/openapi.transformed.yml
+++ b/api_reference/openapi.transformed.yml
@@ -34062,6 +34062,7 @@ components:
         file:
           description: |
             The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+            The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.
           type: string
           x-oaiTypeLabel: file
           format: binary
@@ -34369,7 +34370,7 @@ components:
       properties:
         file:
           description: |
-            The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+            The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.
           type: string
           x-oaiTypeLabel: file
           format: binary

--- a/pkg/cmd/audiotranscription.go
+++ b/pkg/cmd/audiotranscription.go
@@ -21,7 +21,7 @@ var audioTranscriptionsCreate = cli.Command{
 	Flags: []cli.Flag{
 		&requestflag.Flag[string]{
 			Name:      "file",
-			Usage:     "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.\n",
+			Usage:     "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.\nThe request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.\n",
 			Required:  true,
 			BodyPath:  "file",
 			FileInput: true,

--- a/pkg/cmd/audiotranslation.go
+++ b/pkg/cmd/audiotranslation.go
@@ -21,7 +21,7 @@ var audioTranslationsCreate = cli.Command{
 	Flags: []cli.Flag{
 		&requestflag.Flag[string]{
 			Name:      "file",
-			Usage:     "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.\n",
+			Usage:     "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.\n",
 			Required:  true,
 			BodyPath:  "file",
 			FileInput: true,


### PR DESCRIPTION
## Summary

Regenerates the CLI from the latest OpenAPI input.

- Clarifies the metadata requirements shown for transcription and translation file flags.
- Recommends an extension-bearing filename and an appropriate content type.
- Refreshes the transformed OpenAPI document and Castiron provenance.

This is documentation-only; runtime behavior and exported command shapes are unchanged.

## Source

- Originating API change: [openai/openai#1270941](https://github.com/openai/openai/pull/1270941)
- OpenAPI input: [openai/openai-openapi@577fa922](https://github.com/openai/openai-openapi/commit/577fa92299e000af1616f3be1fec740e3383a86a)

## Validation

- Rebased directly onto the current public `main`
- Every changed file matches the Castiron-generated candidate
- `git diff --check`
- `./scripts/lint` with an isolated Go build cache
- Thermo-nuclear code-quality review