### PR TITLE
fix(api): handle nullable stream flags

### DIFF
--- a/pkg/cmd/audiotranscription.go
+++ b/pkg/cmd/audiotranscription.go
@@ -129,7 +129,7 @@ func handleAudioTranscriptionsCreate(ctx context.Context, cmd *cli.Command) erro
 	format := cmd.Root().String("format")
 	explicitFormat := cmd.Root().IsSet("format")
 	transform := cmd.Root().String("transform")
-	if cmd.Bool("stream") {
+	if streamFlagValue, _ := cmd.Value("stream").(*bool); streamFlagValue != nil && *streamFlagValue {
 		stream := client.Audio.Transcriptions.NewStreaming(ctx, params, options...)
 		maxItems := int64(-1)
 		if cmd.IsSet("max-items") {

--- a/pkg/cmd/betaresponse.go
+++ b/pkg/cmd/betaresponse.go
@@ -487,7 +487,7 @@ func handleBetaResponsesCreate(ctx context.Context, cmd *cli.Command) error {
 	format := cmd.Root().String("format")
 	explicitFormat := cmd.Root().IsSet("format")
 	transform := cmd.Root().String("transform")
-	if cmd.Bool("stream") {
+	if streamFlagValue, _ := cmd.Value("stream").(*bool); streamFlagValue != nil && *streamFlagValue {
 		stream := client.Beta.Responses.NewStreaming(ctx, params, options...)
 		maxItems := int64(-1)
 		if cmd.IsSet("max-items") {

--- a/pkg/cmd/betathread.go
+++ b/pkg/cmd/betathread.go
@@ -474,7 +474,7 @@ func handleBetaThreadsCreateAndRun(ctx context.Context, cmd *cli.Command) error 
 	format := cmd.Root().String("format")
 	explicitFormat := cmd.Root().IsSet("format")
 	transform := cmd.Root().String("transform")
-	if cmd.Bool("stream") {
+	if streamFlagValue, _ := cmd.Value("stream").(*bool); streamFlagValue != nil && *streamFlagValue {
 		stream := client.Beta.Threads.NewAndRunStreaming(ctx, params, options...)
 		maxItems := int64(-1)
 		if cmd.IsSet("max-items") {

--- a/pkg/cmd/betathreadrun.go
+++ b/pkg/cmd/betathreadrun.go
@@ -348,7 +348,7 @@ func handleBetaThreadsRunsCreate(ctx context.Context, cmd *cli.Command) error {
 	format := cmd.Root().String("format")
 	explicitFormat := cmd.Root().IsSet("format")
 	transform := cmd.Root().String("transform")
-	if cmd.Bool("stream") {
+	if streamFlagValue, _ := cmd.Value("stream").(*bool); streamFlagValue != nil && *streamFlagValue {
 		stream := client.Beta.Threads.Runs.NewStreaming(
 			ctx,
 			cmd.Value("thread-id").(string),
@@ -645,7 +645,7 @@ func handleBetaThreadsRunsSubmitToolOutputs(ctx context.Context, cmd *cli.Comman
 	format := cmd.Root().String("format")
 	explicitFormat := cmd.Root().IsSet("format")
 	transform := cmd.Root().String("transform")
-	if cmd.Bool("stream") {
+	if streamFlagValue, _ := cmd.Value("stream").(*bool); streamFlagValue != nil && *streamFlagValue {
 		stream := client.Beta.Threads.Runs.SubmitToolOutputsStreaming(
 			ctx,
 			cmd.Value("thread-id").(string),

--- a/pkg/cmd/chatcompletion.go
+++ b/pkg/cmd/chatcompletion.go
@@ -433,7 +433,7 @@ func handleChatCompletionsCreate(ctx context.Context, cmd *cli.Command) error {
 	format := cmd.Root().String("format")
 	explicitFormat := cmd.Root().IsSet("format")
 	transform := cmd.Root().String("transform")
-	if cmd.Bool("stream") {
+	if streamFlagValue, _ := cmd.Value("stream").(*bool); streamFlagValue != nil && *streamFlagValue {
 		stream := client.Chat.Completions.NewStreaming(ctx, params, options...)
 		maxItems := int64(-1)
 		if cmd.IsSet("max-items") {

--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -168,7 +168,7 @@ func handleCompletionsCreate(ctx context.Context, cmd *cli.Command) error {
 	format := cmd.Root().String("format")
 	explicitFormat := cmd.Root().IsSet("format")
 	transform := cmd.Root().String("transform")
-	if cmd.Bool("stream") {
+	if streamFlagValue, _ := cmd.Value("stream").(*bool); streamFlagValue != nil && *streamFlagValue {
 		stream := client.Completions.NewStreaming(ctx, params, options...)
 		maxItems := int64(-1)
 		if cmd.IsSet("max-items") {

--- a/pkg/cmd/image.go
+++ b/pkg/cmd/image.go
@@ -319,7 +319,7 @@ func handleImagesEdit(ctx context.Context, cmd *cli.Command) error {
 	format := cmd.Root().String("format")
 	explicitFormat := cmd.Root().IsSet("format")
 	transform := cmd.Root().String("transform")
-	if cmd.Bool("stream") {
+	if streamFlagValue, _ := cmd.Value("stream").(*bool); streamFlagValue != nil && *streamFlagValue {
 		stream := client.Images.EditStreaming(ctx, params, options...)
 		maxItems := int64(-1)
 		if cmd.IsSet("max-items") {
@@ -375,7 +375,7 @@ func handleImagesGenerate(ctx context.Context, cmd *cli.Command) error {
 	format := cmd.Root().String("format")
 	explicitFormat := cmd.Root().IsSet("format")
 	transform := cmd.Root().String("transform")
-	if cmd.Bool("stream") {
+	if streamFlagValue, _ := cmd.Value("stream").(*bool); streamFlagValue != nil && *streamFlagValue {
 		stream := client.Images.GenerateStreaming(ctx, params, options...)
 		maxItems := int64(-1)
 		if cmd.IsSet("max-items") {

--- a/pkg/cmd/response.go
+++ b/pkg/cmd/response.go
@@ -450,7 +450,7 @@ func handleResponsesCreate(ctx context.Context, cmd *cli.Command) error {
 	format := cmd.Root().String("format")
 	explicitFormat := cmd.Root().IsSet("format")
 	transform := cmd.Root().String("transform")
-	if cmd.Bool("stream") {
+	if streamFlagValue, _ := cmd.Value("stream").(*bool); streamFlagValue != nil && *streamFlagValue {
 		stream := client.Responses.NewStreaming(ctx, params, options...)
 		maxItems := int64(-1)
 		if cmd.IsSet("max-items") {


### PR DESCRIPTION
## Summary

Nullable API request schemas expose `stream` as a `*bool` CLI flag value. The generated handlers previously called `cmd.Bool("stream")`, which expects a concrete boolean and can fail when the nullable flag value is nil.

This regenerates the ten affected streaming handlers with a nil-safe pointer check before selecting the streaming request path. Non-nullable stream flags remain unchanged. The generator change is in [openai/openai#1230579](https://github.com/openai/openai/pull/1230579).

Key review points:
- `pkg/cmd/*.go`: only the affected generated streaming checks changed.
- Castiron rendered 155 CLI files from the current OpenAPI/config inputs; the three-way overlay applied cleanly with zero conflicts and produced this eight-file diff.

## Test Plan
### Automated
- `target/release/castiron generate sdk ... --language cli`: passed; 155 files rendered, formatted, and overlaid cleanly.
- `GOFLAGS=-buildvcs=false ./scripts/lint`: passed.
- `./scripts/test`: all functional Go tests passed; the script later exited nonzero when its teardown trap tried to kill an already-exited mock-server PID.
- `GOOS=windows GOARCH=amd64 go test -c ./... -o /tmp/openai-cli-windows-tests/`: passed.
- `git diff --check`: passed.
