### PR TITLE
ci: fix CodeQL permissions for private repositories

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      actions: read
       contents: read
       security-events: write
     strategy:


### PR DESCRIPTION
## Summary

- Grant the CodeQL analysis job `actions: read` alongside its existing `contents: read` and `security-events: write` permissions.
- Restore both Go and GitHub Actions CodeQL analysis in the mirrored private CLI repository.

## Why

CodeQL reads Actions workflow-run metadata before uploading SARIF results. Public repository metadata can be read without an explicit Actions grant, but the identical workflow in the private mirror fails with `Resource not accessible by integration`.

## Validation

- Parsed the workflow as YAML and verified the complete least-privilege permission set.
- Confirmed the PR changes only one line in `.github/workflows/codeql.yml`.
- Verified the exact commit passed both internal CodeQL jobs, `Analyze (actions)` and `Analyze (go)`: https://github.com/openai/openai-cli-internal/actions/runs/31671277475