### PR TITLE
docs(api): describe response stream event unions

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: f219b0d1-b0dc-4227-ac9d-acea737e460f
-openapi_spec_hash: 15849b9fe3deb3c72da0825905cc0ad9
-openapi_transformed_spec_hash: 9a60ddf3a1c752e15eb43fce666d6da8
+generation_id: 9cae2193-04c5-4661-936c-f79ce8eba993
+openapi_spec_hash: 143aa2ed6323d61a1834c74044e29d30
+openapi_transformed_spec_hash: 5af6fa4fd590fcc79ba2fdd69b9f7b82
 config_hash: fcda4ecfe265daddba6fad25a8504a3f
-codegen_sha: 7026cba81c967a165fa40b84f09c56d3d17f4fe3
+codegen_sha: 445e9c2294825399ed99aa5528100913dd377657

--- a/api_reference/openapi.transformed.yml
+++ b/api_reference/openapi.transformed.yml
@@ -54296,6 +54296,7 @@ components:
             "sequence_number": 1
           }
     ResponseStreamEvent:
+      description: Event emitted while a response is streamed.
       anyOf:
       - $ref: '#/components/schemas/ResponseAudioDeltaEvent'
       - $ref: '#/components/schemas/ResponseAudioDoneEvent'
@@ -77148,6 +77149,7 @@ components:
               when the originating `response.create` event supplied a
               `stream_id`.
     BetaResponseStreamEvent:
+      description: Event emitted while a response is streamed.
       anyOf:
       - $ref: '#/components/schemas/BetaResponseAudioDeltaEvent'
       - $ref: '#/components/schemas/BetaResponseAudioDoneEvent'


### PR DESCRIPTION
## Summary
- Accurately describe stable and beta Responses streaming event unions.
- Refresh generated OpenAPI reference and Castiron provenance from the exact upstream source.
- Source: https://github.com/openai/openai/pull/1277036
- OpenAPI commit: bc61c5299f7f6fdd6061ccad0ac7e4ec0f659098

## Validation
- Castiron local dry run and exact generated-candidate patch comparison.
- git diff --check and transformed OpenAPI reference hash verified.