### PR TITLE
fix(explore): avoid panic when printing an empty result set

### DIFF
--- a/internal/jsonview/explorer.go
+++ b/internal/jsonview/explorer.go
@@ -426,7 +426,15 @@ func (v *JSONViewer) getSelectedContent() string {
 		return v.current().GetData().Raw
 	}
 
-	selected := tableView.rowData[tableView.table.Cursor()]
+	// An empty array or object builds a table with no rows, so there is no row
+	// under the cursor to print. Fall back to the container itself, which is what
+	// the view is already displaying.
+	cursor := tableView.table.Cursor()
+	if cursor < 0 || cursor >= len(tableView.rowData) {
+		return tableView.GetData().Raw
+	}
+
+	selected := tableView.rowData[cursor]
 	if selected.Type == gjson.String {
 		return sanitizeTerminalString(selected.Str)
 	}

--- a/internal/jsonview/explorer_test.go
+++ b/internal/jsonview/explorer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/bubbles/help"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/tidwall/gjson"
 
 	"github.com/stretchr/testify/require"
@@ -31,6 +32,33 @@ func TestNavigateForward_EmptyRowData(t *testing.T) {
 
 	// Stack should remain unchanged (no new view pushed).
 	require.Equal(t, 1, len(viewer.stack), "expected stack length 1, got %d", len(viewer.stack))
+}
+
+func TestGetSelectedContent_EmptyRowData(t *testing.T) {
+	t.Parallel()
+
+	// A list endpoint with no results renders an empty array, and an empty object
+	// is likewise possible; neither produces a row for the cursor to land on.
+	for _, empty := range []string{"[]", "{}"} {
+		t.Run(empty, func(t *testing.T) {
+			t.Parallel()
+
+			view, err := newTableView("", gjson.Parse(empty), false)
+			require.NoError(t, err)
+
+			viewer := &JSONViewer{
+				stack: []JSONView{view},
+				root:  "test",
+				help:  help.New(),
+			}
+
+			// Pressing "p" should print the container rather than panicking.
+			require.NotPanics(t, func() {
+				viewer.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+			})
+			require.Equal(t, empty, viewer.message)
+		})
+	}
 }
 
 // rawJSONItem implements HasRawJSON, returning pre-built JSON.


### PR DESCRIPTION
### Summary

Pressing `p` ("print and exit") in the `--format explore` viewer panics when the result set is empty.

`getSelectedContent` indexes `rowData` at the table cursor without checking that a row exists:

https://github.com/openai/openai-cli/blob/7d87ee2/internal/jsonview/explorer.go#L423-L434

An empty array or object builds a `TableView` with no rows, `table.Cursor()` returns `0`, and the index panics.

`navigateForward` already guards this exact case (added in `TestNavigateForward_EmptyRowData`), so this looks like the same oversight in the sibling path rather than an intended difference.

### How it is reached

Any list endpoint that returns no results. `ExploreJSONStream` collects zero items, `marshalItemsToJSONArray` returns `[]`, and `newTableView` builds a table with no rows:

https://github.com/openai/openai-cli/blob/7d87ee2/internal/jsonview/explorer.go#L331-L349

So on an account with no files:

```sh
openai files list --format explore
```

then press `p`, and the CLI exits with a runtime panic and a Go stack trace instead of printing anything. The same applies to a top level empty object via `ExploreJSON`.

Every other key binding (`↑`, `↓`, `←`, `→`, `r`, `q`) already handles the empty view fine. `p` is the only one that crashes.

### Reproduction

Reverting just the one line change and running the test added here:

```
--- FAIL: TestGetSelectedContent_EmptyRowData (0.00s)
    --- FAIL: TestGetSelectedContent_EmptyRowData/[] (0.00s)
        Error: func (assert.PanicTestFunc) should not panic
            Panic value: runtime error: index out of range [0] with length 0
            Panic stack:
            github.com/openai/openai-cli/internal/jsonview.(*JSONViewer).getSelectedContent
                internal/jsonview/explorer.go:429
            github.com/openai/openai-cli/internal/jsonview.(*JSONViewer).Update
                internal/jsonview/explorer.go:415
```

With the fix applied, both cases pass.

### Fix

Bounds check the cursor before indexing, and fall back to the container the view is already displaying, so `p` prints `[]` or `{}`. That matches the existing fallback for non table views a few lines above, which returns `GetData().Raw`.

The test drives `Update` with the actual `p` key message rather than calling the unexported helper directly, so it covers the real key binding path and asserts the printed output, not just the absence of a panic.

### Notes

- No behavior change for non empty views: the cursor is always in range there, so the existing branch is taken unchanged.
- `go build ./...` and `go vet ./...` are clean; `go test ./internal/...` passes apart from `internal/autocomplete`, which fails identically on an unmodified checkout in my environment (it shells out to `/bin/bash` and I am on Windows), so it is unrelated to this change.
