### PR TITLE
chore: configure Dependabot for Go and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directories:
+      - /
+      - /api_reference
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Etc/UTC
+    cooldown:
+      default-days: 8
+    open-pull-requests-limit: 5
+    groups:
+      charmbracelet:
+        patterns:
+          - "github.com/charmbracelet/*"
+        update-types:
+          - minor
+          - patch
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+        update-types:
+          - minor
+          - patch
+      go-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    # The hourly update-openai-go workflow owns this dependency, including fixes.
+    ignore:
+      - dependency-name: "github.com/openai/openai-go/v3"
+
+  - package-ecosystem: github-actions
+    # Root scans workflows; setup-go also has its own composite action manifest.
+    directories:
+      - /
+      - /.github/actions/setup-go
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Etc/UTC
+    cooldown:
+      default-days: 8
+    open-pull-requests-limit: 5
+    groups:
+      setup-go:
+        patterns:
+          - "actions/setup-go"
+      codeql:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,7 @@ updates:
     open-pull-requests-limit: 5
     groups:
       setup-go:
+        group-by: dependency-name
         patterns:
           - "actions/setup-go"
       codeql:


### PR DESCRIPTION
## Summary

- Add Dependabot coverage for both Go module manifests, repository workflows, and the nested `setup-go` composite action.
- Schedule routine updates weekly with an eight-day release-age cooldown, at most five open version-update PRs per ecosystem, and targeted Go dependency, `setup-go`, and CodeQL groups. Dependabot security updates are not delayed by the cooldown.
- Preserve the existing hourly `update-openai-go` workflow as the sole owner of `github.com/openai/openai-go/v3`, avoiding duplicate or conflicting SDK release PRs. Because Dependabot ignores this SDK dependency, the hourly updater remains responsible for both its routine updates and security fixes.

## Validation

- Parsed the YAML with duplicate-key rejection and validated it against the current Dependabot v2 JSON schema.
- Verified configured directories exactly cover both `go.mod` manifests, repository workflows, and the nested composite action; checked schedules, cooldowns, PR limits, related-action grouping, and hourly SDK updater ownership.
- `go test ./internal/...`
- `go test ./... -run '^$'` (compile every Go test package without requiring the external mock server)
- `./scripts/lint`
- `go mod verify`

Go checks used writable temporary caches; build commands disabled VCS stamping because this task runs from an isolated linked worktree.