### PR TITLE
chore(deps): configure Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+version: 2
+
+updates:
+  # api_reference/go.mod has no dependencies; the root is the only active module.
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Etc/UTC
+    # Security updates are not subject to version-update cooldowns.
+    cooldown:
+      default-days: 8
+    open-pull-requests-limit: 5
+    groups:
+      charmbracelet:
+        patterns:
+          - "github.com/charmbracelet/*"
+        update-types:
+          - minor
+          - patch
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+        update-types:
+          - minor
+          - patch
+      go-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github.com/charmbracelet/*"
+          - "golang.org/x/*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # The hourly SDK updater owns this dependency and its release automation.
+      - dependency-name: github.com/openai/openai-go/v3
+
+  - package-ecosystem: github-actions
+    directories:
+      - /
+      - /.github/actions/setup-go
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Etc/UTC
+    cooldown:
+      default-days: 8
+    open-pull-requests-limit: 5
+    groups:
+      setup-go:
+        # Keep the composite action and release workflow on the same pinned SHA.
+        group-by: dependency-name
+        patterns:
+          - actions/setup-go
+      codeql:
+        patterns:
+          - "github/codeql-action/*"
+      artifact-actions:
+        patterns:
+          - actions/upload-artifact
+          - actions/download-artifact


### PR DESCRIPTION
## Summary

- Add weekly Dependabot updates for the root Go module and for GitHub Actions in both repository workflows and the local `setup-go` composite action.
- Apply an eight-day package-age cooldown to version updates without delaying Dependabot security updates, cap each ecosystem at five open pull requests, and group related non-breaking Go updates plus coordinated CodeQL, artifact, and cross-directory `setup-go` action updates.
- Preserve the existing hourly OpenAI Go SDK updater by excluding `github.com/openai/openai-go/v3`, and avoid scheduling a useless job for the dependency-free `api_reference/go.mod` boundary module.

## Validation

- Parsed the YAML with duplicate-key detection and validated it against the current published Dependabot JSON schema.
- Verified every active Go module, workflow and composite-action directory, action update group, existing SDK updater, schedule, cooldown, and pull-request limit against the checked-out repository.
- `GOFLAGS=-buildvcs=false ./scripts/lint`
- `GOFLAGS=-buildvcs=false go test ./internal/...`
- `GOFLAGS=-buildvcs=false go test ./pkg/cmd -run '^(TestMTLSClientFlags|TestNewMTLSHTTPClient|TestIsUTF8TextFile|TestValidateBaseURL|TestFormatJSON)$'`
- `GOFLAGS=-buildvcs=false go test ./... -run '^$'`
- `git diff --check`

Local checks use `-buildvcs=false` because the desktop workspace contains a placeholder parent `.git` directory that Go incorrectly selects when the repository is checked out as a linked worktree; repository files and CI settings are unchanged. Full generated CLI integration tests require the Steady mock server on shared port 4010, so local verification runs all internal unit tests and compiles every package without starting or stopping a shared service.
