### PR TITLE
docs: standardize CLI vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,33 @@
 # Security Policy
 
-## Reporting Security Issues
+## Reporting a vulnerability
 
-To report a security issue in the OpenAI CLI, email disclosure@openai.com.
+Report suspected vulnerabilities in the OpenAI CLI privately by emailing
+disclosure@openai.com. Follow OpenAI's
+[coordinated vulnerability disclosure policy](https://openai.com/policies/coordinated-vulnerability-disclosure-policy).
 
-Please follow OpenAI's coordinated vulnerability disclosure policy:
-https://openai.com/policies/coordinated-vulnerability-disclosure-policy
+Do not report security vulnerabilities through public GitHub issues, pull requests, or discussions.
 
-Do not disclose the issue publicly until OpenAI has had a reasonable opportunity to investigate and address it.
+This policy covers the OpenAI CLI, source code in this repository, and official
+release artifacts. For security issues in other OpenAI products or services,
+use the same OpenAI disclosure process.
 
-## Scope
+## What to include
 
-This policy applies to the OpenAI CLI and its release artifacts. For security issues in OpenAI services or other OpenAI products, use the same OpenAI disclosure process.
+Please include:
+
+- The affected package or product and version, release artifact, or commit.
+- A clear description of the potential security impact.
+- Sanitized steps to reproduce the issue or a minimal proof of concept.
+- Relevant environment details, such as operating system, architecture, and
+  installation method.
+- Any known mitigations or workarounds.
+
+Do not include live credentials, API keys, customer data, or unredacted sensitive logs.
+Remove access tokens, private keys, authorization headers, signed URLs, and
+sensitive request or response content before sharing supporting information.
+
+## Coordinated disclosure
+
+Please give the maintainers a reasonable opportunity to investigate and address the issue before public disclosure.
+Thank you for helping keep the OpenAI CLI and its users secure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ Report suspected vulnerabilities in the OpenAI CLI privately by emailing
 disclosure@openai.com. Follow OpenAI's
 [coordinated vulnerability disclosure policy](https://openai.com/policies/coordinated-vulnerability-disclosure-policy).
 
-Do not report security vulnerabilities through public GitHub issues, pull requests, or discussions.
+Do not report security vulnerabilities through public GitHub issues, pull
+requests, or discussions.
 
 This policy covers the OpenAI CLI, source code in this repository, and official
 release artifacts. For security issues in other OpenAI products or services,
@@ -23,11 +24,13 @@ Please include:
   installation method.
 - Any known mitigations or workarounds.
 
-Do not include live credentials, API keys, customer data, or unredacted sensitive logs.
+Do not include live credentials, API keys, customer data, or unredacted
+sensitive logs.
 Remove access tokens, private keys, authorization headers, signed URLs, and
 sensitive request or response content before sharing supporting information.
 
 ## Coordinated disclosure
 
-Please give the maintainers a reasonable opportunity to investigate and address the issue before public disclosure.
+Please give the maintainers a reasonable opportunity to investigate and
+address the issue before public disclosure.
 Thank you for helping keep the OpenAI CLI and its users secure.


### PR DESCRIPTION
## Summary

- Standardize the root `SECURITY.md` on the shared **Reporting a vulnerability**, **What to include**, and **Coordinated disclosure** sections and exact cross-SDK warning language.
- Preserve the CLI's existing private `disclosure@openai.com` reporting destination, OpenAI coordinated-disclosure policy URL, official CLI/release-artifact scope, and guidance for other OpenAI products.
- Explicitly prohibit public GitHub vulnerability reports and sensitive credentials/customer data in reports; request affected versions or artifacts, impact, sanitized reproduction steps, environment details, and known mitigations.
- Retain respectful coordinated disclosure without changing repository settings, private-reporting configuration, application code, dependencies, or release automation.

## Validation

- Passed 40 focused CommonMark structure, exact shared-policy wording, reporting-channel preservation, sensitive-data, CLI/release-artifact scope, and single-file diff checks.
- Confirmed the preserved OpenAI coordinated-disclosure policy URL returns HTTP 200.
- `git diff --check origin/main -- SECURITY.md`
- `go test ./internal/...`
