### PR TITLE
ci: run CodeQL on pull requests and merge queues

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,12 +7,15 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
 
 permissions: {}
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary

- Add `merge_group: checks_requested` to the existing advanced CodeQL workflow so the same real GitHub Actions and Go analyses run for merge-queue commits as well as existing pull requests and pushes to `main`.
- Give the matrix jobs deterministic, unique future gate names: `CodeQL (actions)` and `CodeQL (go)`. The current `Analyze (go)` context collides with the repository's separate dynamic organization-managed code-quality workflow, so it is not a safe required-check identifier.
- Preserve the existing `actions: read`, `contents: read`, and `security-events: write` permissions; immutable checkout/CodeQL action SHAs; `persist-credentials: false`; language/build-mode matrix; real CodeQL initialization/analysis; and required maintainer approval for external fork PRs.
- Change only `.github/workflows/codeql.yml` (four added lines and one job-name replacement); do not modify documentation, Dependabot, release workflows, repository settings, or the live ruleset.

## Safe required-check rollout

The current `main` ruleset requires `build`, `lint`, and `test` and uses a merge queue. Historical inspection found **23 `merge_group` runs and zero CodeQL merge-group runs**. Requiring either new CodeQL context before the workflow lands and both contexts are observed succeeding on an actual merge-group commit could deadlock every legitimate merge.

After this workflow is merged and `CodeQL (actions)` plus `CodeQL (go)` have both succeeded on eligible `pull_request` and actual `merge_group` paths, a repository administrator can safely add those two exact GitHub Actions contexts (`integration_id: 15368`) to ruleset `19328880`, preserving the existing required checks and fork-contributor approval policy.

## Validation

- Passed 42 focused YAML 1.2/duplicate-key and current GitHub Actions schema checks covering event behavior, real analysis steps, matrix languages, check-name uniqueness, fork safety, least privilege, full SHA pins, existing merge-queue rules, and exact one-file scope.
- Verified existing external fork PRs require maintainer approval (`approval_policy: all_external_contributors`); no `pull_request_target`, privileged checkout, path filter, placeholder check, or secret exposure was introduced.
- `git diff --check origin/main -- .github/workflows/codeql.yml`
- `go test ./internal/...`
- `go mod verify`
- `./scripts/lint`
