### PR TITLE
ci: enforce least-privilege GitHub Actions permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 name: CI
-permissions:
-  contents: read
+permissions: {}
 on:
   push:
     branches:
@@ -14,6 +13,8 @@ jobs:
   lint:
     timeout-minutes: 10
     name: lint
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -62,8 +63,7 @@ jobs:
     needs:
       - build-artifacts
     if: always()
-    permissions:
-      contents: read
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - name: Require successful build
@@ -78,6 +78,8 @@ jobs:
   test:
     timeout-minutes: 10
     name: test
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -1,4 +1,5 @@
 name: Create releases
+permissions: {}
 on:
   schedule:
     - cron: '0 5 * * *' # every day at 5am UTC

--- a/.github/workflows/dispatch-publish-release.yml
+++ b/.github/workflows/dispatch-publish-release.yml
@@ -1,7 +1,6 @@
 ---
 name: Dispatch Publish Release
-permissions:
-  actions: write
+permissions: {}
 
 on:
   push:
@@ -11,6 +10,8 @@ on:
 jobs:
   dispatch:
     if: github.repository == 'openai/openai-cli'
+    permissions:
+      actions: write
     runs-on: ubuntu-latest
     steps:
     - name: Dispatch Publish Release on main

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,6 +1,8 @@
 ---
 name: Publish Release
 
+permissions: {}
+
 concurrency:
   group: publish
 


### PR DESCRIPTION
## Summary

- Set `permissions: {}` at the workflow level for CI, release creation, release dispatch, and release publication so all six committed workflows deny inherited `GITHUB_TOKEN` privileges by default.
- Grant `contents: read` only to CI jobs that actually check out source; remove the unnecessary token grant from the shell-only required `build` aggregation job.
- Confine `actions: write` to the release-dispatch job that invokes `publish-release.yml`; preserve existing independently scoped GitHub App tokens, release environments, macOS signing/notarization, Homebrew publication, OIDC artifact attestations, CodeQL uploads, fork approvals, SHA-pinned Actions, required-check names, and merge-queue behavior.
- Change only four existing workflow files; the separate CodeQL, Dependabot, and documentation changes remain untouched.

## External repository setting recommendation (not changed)

Read-only inspection currently reports `default_workflow_permissions: write` and `can_approve_pull_request_reviews: true`. After reviewing existing GitHub App-based release/dependency automation, a separately authorized repository owner should set **Settings → Actions → General → Workflow permissions** to **Read repository contents and packages permissions** and disable **Allow GitHub Actions to create and approve pull requests**. This PR intentionally does not change repository settings, protected environments, approval rules, or credentials.

## Validation

- Passed **130 focused YAML 1.2/duplicate-key and GitHub Actions schema checks** across all six workflows, including exact minimum job permissions, structural equivalence apart from permission scopes, SHA pins, fork safety, stable required checks/merge queue, GitHub App token grants, signing references, OIDC/attestations, and exact four-file scope.
- `git diff --check origin/main -- .github/workflows/ci.yml .github/workflows/create-releases.yml .github/workflows/dispatch-publish-release.yml .github/workflows/publish-release.yml`
- `go test ./internal/...`
- `go mod verify`
- `GOFLAGS=-buildvcs=false ./scripts/lint` (VCS stamping disabled only because the sandbox cannot inspect worktree metadata; no production workflow behavior changed).