### PR TITLE
fix(apiquery): preserve narrow numeric parameters

### DIFF
--- a/internal/apiquery/encoder.go
+++ b/internal/apiquery/encoder.go
@@ -135,13 +135,16 @@ func (e *encoder) encodePrimitive(key string, value reflect.Value) ([]Pair, erro
 		}
 		return []Pair{{key, "false"}}, nil
 
-	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64:
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return []Pair{{key, strconv.FormatInt(value.Int(), 10)}}, nil
 
-	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return []Pair{{key, strconv.FormatUint(value.Uint(), 10)}}, nil
 
-	case reflect.Float32, reflect.Float64:
+	case reflect.Float32:
+		return []Pair{{key, strconv.FormatFloat(value.Float(), 'f', -1, 32)}}, nil
+
+	case reflect.Float64:
 		return []Pair{{key, strconv.FormatFloat(value.Float(), 'f', -1, 64)}}, nil
 
 	default:

--- a/internal/apiquery/query_test.go
+++ b/internal/apiquery/query_test.go
@@ -25,9 +25,21 @@ func TestEncode(t *testing.T) {
 			val: 42,
 			enc: "query=42",
 		},
+		"int8": {
+			val: int8(-8),
+			enc: "query=-8",
+		},
+		"uint8": {
+			val: uint8(8),
+			enc: "query=8",
+		},
 		"float": {
 			val: 3.14,
 			enc: "query=3.14",
+		},
+		"float32": {
+			val: float32(0.1),
+			enc: "query=0.1",
 		},
 		"bool": {
 			val: true,


### PR DESCRIPTION
## Summary

Preserve narrow Go numeric values when encoding URL query parameters.

Fixes #75.

## Problem

`internal/apiquery` currently has two width-related serialization gaps:

- `int8` and `uint8` are not included in the primitive integer cases, so they silently produce no query pair;
- `float32` shares the `float64` formatting path and is passed to `strconv.FormatFloat` with `bitSize=64`, exposing precision introduced only when reflection widens the value to a Go `float64`.

A caller can therefore omit a legitimate numeric query parameter entirely, or send a decimal representation different from the source `float32` value.

## Reproduction

On upstream `main` at `d082a010f7c6cacf407d8a1581446a7857f9f1bb`:

```go
values, _ := apiquery.Marshal(map[string]any{"value": int8(-8)})
// values.Encode() == ""

values, _ = apiquery.Marshal(map[string]any{"value": uint8(8)})
// values.Encode() == ""

values, _ = apiquery.Marshal(map[string]any{"value": float32(0.1)})
// values.Get("value") == "0.10000000149011612"
```

## Root cause

The primitive switch omitted the 8-bit integer kinds and grouped both floating-point kinds behind:

```go
strconv.FormatFloat(value.Float(), 'f', -1, 64)
```

`reflect.Value.Float()` returns a `float64`, but `FormatFloat`'s `bitSize` argument is specifically what tells it whether the original value should be represented with 32-bit or 64-bit precision.

The sibling multipart/form encoder already follows that distinction for primitive values.

## Fix

- include `reflect.Int8` with the signed integer kinds;
- include `reflect.Uint8` with the unsigned integer kinds;
- format `reflect.Float32` with `bitSize=32`;
- retain `bitSize=64` for `reflect.Float64`.

No query key formatting, array formatting, nesting rules, null handling, or existing wider numeric behavior changes.

## Regression coverage

Extended the existing table-driven `TestEncode` cases with:

- `int8(-8)` -> `query=-8`;
- `uint8(8)` -> `query=8`;
- `float32(0.1)` -> `query=0.1`.

These cases fail on current `main` for the reasons described above and exercise the real `MarshalWithSettings` path rather than an isolated helper.

## Validation

The branch is based directly on current upstream `main` and is not behind it. The diff is limited to:

- 6 additions / 3 deletions in `internal/apiquery/encoder.go`;
- 12 lines of focused regression coverage in `internal/apiquery/query_test.go`.

Full repository validation is left to the repository's GitHub Actions checks.

## Risk

Low. The change only fills missing primitive cases and uses the source floating-point width when choosing the standard-library formatting precision. Existing `int`, wider integer, and `float64` output is unchanged.

BEGIN_COMMIT_OVERRIDE
fix(apiquery): preserve narrow numeric parameters (#76)
END_COMMIT_OVERRIDE
