### PR TITLE
fix(apiform): preserve float32 precision in comma arrays

### DIFF
--- a/internal/apiform/encoder.go
+++ b/internal/apiform/encoder.go
@@ -118,7 +118,9 @@ func (e *encoder) encodeArray(key string, val reflect.Value, writer *multipart.W
 				strValue = strconv.FormatInt(item.Int(), 10)
 			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 				strValue = strconv.FormatUint(item.Uint(), 10)
-			case reflect.Float32, reflect.Float64:
+			case reflect.Float32:
+				strValue = strconv.FormatFloat(item.Float(), 'f', -1, 32)
+			case reflect.Float64:
 				strValue = strconv.FormatFloat(item.Float(), 'f', -1, 64)
 			case reflect.Bool:
 				strValue = strconv.FormatBool(item.Bool())

--- a/internal/apiform/form_test.go
+++ b/internal/apiform/form_test.go
@@ -28,6 +28,10 @@ var tests = map[string]struct {
 		value:    3.14,
 		expected: "--xxx\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\n3.14\r\n--xxx--\r\n",
 	},
+	"float32": {
+		value:    float32(0.1),
+		expected: "--xxx\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\n0.1\r\n--xxx--\r\n",
+	},
 	"bool": {
 		value:    true,
 		expected: "--xxx\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\ntrue\r\n--xxx--\r\n",
@@ -59,6 +63,11 @@ var tests = map[string]struct {
 		value:    []int{10, 20, 30},
 		format:   FormatComma,
 		expected: "--xxx\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\n10,20,30\r\n--xxx--\r\n",
+	},
+	"float32 slice with commas": {
+		value:    []float32{0.1, 1.5},
+		format:   FormatComma,
+		expected: "--xxx\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\n0.1,1.5\r\n--xxx--\r\n",
 	},
 	"empty map": {
 		value:    map[string]any{},


### PR DESCRIPTION
## Summary

Keep multipart comma-array `float32` serialization consistent with the existing scalar `float32` path.

Fixes #77.

## Problem

`internal/apiform` already formats scalar `float32` values with 32-bit precision, but `FormatComma` arrays combine `float32` and `float64` behind a 64-bit formatting call.

That means the same source value can be represented differently depending only on whether it appears by itself or inside a comma-delimited form field.

For example, current `main` serializes:

```go
float32(0.1)
```

as:

```text
0.1
```

but:

```go
[]float32{0.1, 1.5}
```

with `FormatComma` as:

```text
0.10000000149011612,1.5
```

## Root cause

The primitive form path correctly distinguishes widths:

```go
case reflect.Float32:
    strconv.FormatFloat(val.Float(), 'f', -1, 32)
case reflect.Float64:
    strconv.FormatFloat(val.Float(), 'f', -1, 64)
```

The comma-array path instead uses one branch for both kinds and always passes `bitSize=64`. Reflection returns floating-point values as `float64`, so the 64-bit formatting request preserves digits introduced by widening the original `float32`.

## Fix

Split the comma-array branch by source kind:

- `reflect.Float32` -> `FormatFloat(..., 32)`
- `reflect.Float64` -> `FormatFloat(..., 64)`

No multipart boundaries, field names, array-format selection, integer formatting, boolean formatting, or `float64` output changes.

## Regression coverage

The existing table-driven form encoder test now includes:

- a scalar `float32(0.1)` control showing the existing expected representation;
- a `FormatComma` `[]float32{0.1, 1.5}` regression requiring `0.1,1.5`.

The comma-array case fails on current upstream `main`, while the scalar control demonstrates the consistency requirement directly.

## Validation

The branch is based directly on upstream `main` at `d082a010f7c6cacf407d8a1581446a7857f9f1bb` and is not behind it.

Production diff: 3 additions and 1 deletion in `internal/apiform/encoder.go`, plus focused table-driven coverage in `internal/apiform/form_test.go`.

Full repository validation is left to the repository's GitHub Actions checks.

## Risk

Low. Only the textual formatting of `float32` values inside `FormatComma` arrays changes, and it becomes identical to the width-aware behavior already used for scalar `float32` fields. `float64` and all non-floating form values are unchanged.