### PR TITLE
fix(jsonview): preserve literal object keys in pretty output

### DIFF
--- a/internal/jsonview/staticdisplay.go
+++ b/internal/jsonview/staticdisplay.go
@@ -100,10 +100,11 @@ func formatJSONObject(result gjson.Result, indent, width int) string {
 	if len(keys) == 0 {
 		return nullValueStyle.Render("(empty)")
 	}
+	values := result.Map()
 
 	var items []string
 	for _, key := range keys {
-		value := result.Get(key.Str)
+		value := values[key.Str]
 		keyStr := getIndent(indent) + keyStyle.Render(sanitizeTerminalString(key.Str)+":")
 		// If item will be a one-liner, put it inline after the key, otherwise
 		// it starts with a newline and goes below the key.

--- a/internal/jsonview/staticdisplay_literal_keys_test.go
+++ b/internal/jsonview/staticdisplay_literal_keys_test.go
@@ -1,0 +1,18 @@
+package jsonview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestStaticDisplayUsesLiteralObjectKeys(t *testing.T) {
+	t.Parallel()
+
+	result := gjson.Parse(`{"a.b":"literal-value","a":{"b":"nested-value"}}`)
+	out := formatJSON(result, 80)
+
+	require.Contains(t, out, "literal-value")
+	require.Contains(t, out, "nested-value")
+}


### PR DESCRIPTION
## Summary

Use literal object-member lookup when rendering pretty JSON so keys containing GJSON path syntax display their own values.

Fixes #81.

## Problem

The pretty renderer enumerates real JSON member names with `@keys`, then looks each value up again through `result.Get(key.Str)`.

`Result.Get` does not perform literal map lookup. It parses the supplied string as a GJSON path. That changes the meaning of keys such as `"a.b"`.

For example:

```json
{
  "a.b": "literal-value",
  "a": {
    "b": "nested-value"
  }
}
```

The current renderer enumerates `"a.b"` correctly but then resolves `result.Get("a.b")` to the nested `a.b` value. The row for the literal top-level key can therefore display `"nested-value"`, and `"literal-value"` may never appear in the output.

## Root cause

Two incompatible access models are mixed in the same loop:

- `@keys` returns literal object member names;
- `Result.Get` treats those names as path expressions.

This is only safe for keys that contain no GJSON path metacharacters.

## Fix

Materialize the object's literal map once:

```go
values := result.Map()
```

and then index it with the enumerated key:

```go
value := values[key.Str]
```

This also avoids repeatedly reparsing each key as a path.

## Regression coverage

Added a focused regression with both:

- a top-level key named `"a.b"` whose value is `"literal-value"`;
- a nested `a -> b` value named `"nested-value"`.

The test requires both values to remain visible in static pretty output. On current `main`, the literal value is lost because the dotted key resolves the nested path.

## Validation

The branch is based directly on upstream `main` at `d082a010f7c6cacf407d8a1581446a7857f9f1bb` and is not behind it.

Production diff: 2 additions and 1 deletion in `internal/jsonview/staticdisplay.go`, plus one focused regression file.

Full repository validation is left to the repository's GitHub Actions checks.

## Risk

Low. The renderer already has the literal key names. The change only uses ordinary object-member lookup for those keys instead of reinterpreting them as query expressions. Objects with simple keys retain the same displayed values.