### PR TITLE
fix: reject invalid multipart MIME header controls

### DIFF
--- a/internal/apiform/encoder.go
+++ b/internal/apiform/encoder.go
@@ -41,6 +41,10 @@ func (e *encoder) marshal(value any, writer *multipart.Writer) error {
 }
 
 func (e *encoder) encodeValue(key string, val reflect.Value, writer *multipart.Writer) error {
+	if err := validateMIMEHeaderValue(key, "field name"); err != nil {
+		return err
+	}
+
 	if !val.IsValid() {
 		return writer.WriteField(key, "")
 	}
@@ -166,6 +170,15 @@ func escapeQuotes(s string) string {
 	return quoteEscaper.Replace(s)
 }
 
+func validateMIMEHeaderValue(value, component string) error {
+	for i := 0; i < len(value); i++ {
+		if (value[i] < ' ' && value[i] != '\t') || value[i] == '\x7f' {
+			return fmt.Errorf("apiform: invalid control character in multipart %s", component)
+		}
+	}
+	return nil
+}
+
 func (e *encoder) encodeReader(key string, val reflect.Value, writer *multipart.Writer) error {
 	reader, ok := val.Convert(reflect.TypeOf((*io.Reader)(nil)).Elem()).Interface().(io.Reader)
 	if !ok {
@@ -186,6 +199,13 @@ func (e *encoder) encodeReader(key string, val reflect.Value, writer *multipart.
 	// Get content type if available
 	if typed, ok := reader.(interface{ ContentType() string }); ok {
 		contentType = typed.ContentType()
+	}
+
+	if err := validateMIMEHeaderValue(filename, "filename"); err != nil {
+		return err
+	}
+	if err := validateMIMEHeaderValue(contentType, "content type"); err != nil {
+		return err
 	}
 
 	h := make(textproto.MIMEHeader)

--- a/internal/apiform/encoder_security_test.go
+++ b/internal/apiform/encoder_security_test.go
@@ -1,0 +1,252 @@
+package apiform
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+)
+
+func TestMarshalRejectsInvalidMIMEHeaderControls(t *testing.T) {
+	t.Parallel()
+
+	type controlCase struct {
+		name  string
+		value string
+	}
+	controls := make([]controlCase, 0, 32)
+	for value := byte(0); value < ' '; value++ {
+		if value == '\t' {
+			continue
+		}
+		name := fmt.Sprintf("0x%02x", value)
+		switch value {
+		case '\x00':
+			name = "NUL"
+		case '\n':
+			name = "LF"
+		case '\r':
+			name = "CR"
+		}
+		controls = append(controls, controlCase{name: name, value: string(value)})
+	}
+	controls = append(controls, controlCase{name: "DEL", value: "\x7f"})
+
+	for _, control := range controls {
+		t.Run(control.name, func(t *testing.T) {
+			t.Parallel()
+
+			injected := "before" + control.value + "X-Injected: value"
+			cases := []struct {
+				name   string
+				value  any
+				format FormFormat
+			}{
+				{
+					name:  "scalar field name",
+					value: map[string]any{injected: "value"},
+				},
+				{
+					name:  "nil field name",
+					value: map[string]any{injected: nil},
+				},
+				{
+					name: "file field name",
+					value: map[string]any{injected: multipartSecurityFile{
+						Reader:      strings.NewReader("contents"),
+						filename:    "valid.txt",
+						contentType: "text/plain",
+					}},
+				},
+				{
+					name:  "nested dotted field name",
+					value: map[string]any{"outer": map[string]any{injected: "value"}},
+				},
+				{
+					name:   "nested bracketed field name",
+					value:  map[string]any{"outer": map[string]any{injected: "value"}},
+					format: FormatBrackets,
+				},
+				{
+					name:   "comma-separated field name",
+					value:  map[string]any{injected: []string{"first", "second"}},
+					format: FormatComma,
+				},
+				{
+					name: "filename",
+					value: map[string]any{"file": multipartSecurityFile{
+						Reader:      strings.NewReader("contents"),
+						filename:    injected,
+						contentType: "text/plain",
+					}},
+				},
+				{
+					name: "reader Name filename",
+					value: map[string]any{"file": multipartSecurityNamedReader{
+						Reader: strings.NewReader("contents"),
+						name:   "/tmp/" + injected,
+					}},
+				},
+				{
+					name: "content type",
+					value: map[string]any{"file": multipartSecurityFile{
+						Reader:      strings.NewReader("contents"),
+						filename:    "valid.txt",
+						contentType: "text/plain" + control.value + "X-Injected: value",
+					}},
+				},
+			}
+
+			for _, test := range cases {
+				t.Run(test.name, func(t *testing.T) {
+					t.Parallel()
+
+					var output bytes.Buffer
+					writer := multipart.NewWriter(&output)
+					if err := MarshalWithSettings(test.value, writer, test.format); err == nil {
+						t.Fatalf("encoding unexpectedly accepted a %s control in %s", control.name, test.name)
+					}
+					if output.Len() != 0 {
+						t.Errorf("invalid part wrote %d bytes before being rejected", output.Len())
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestMarshalRejectsNestedJSONAndYAMLFieldNames(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		input  string
+		decode func([]byte, any) error
+	}{
+		{
+			name:   "JSON",
+			input:  `{"outer":{"bad\r\nX-Injected: value":"contents"}}`,
+			decode: json.Unmarshal,
+		},
+		{
+			name:   "YAML",
+			input:  "outer:\n  \"bad\\r\\nX-Injected: value\": contents\n",
+			decode: yaml.Unmarshal,
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var value map[string]any
+			if err := test.decode([]byte(test.input), &value); err != nil {
+				t.Fatalf("decode input: %v", err)
+			}
+
+			for _, format := range []FormFormat{FormatRepeat, FormatBrackets} {
+				t.Run(fmt.Sprintf("format_%d", format), func(t *testing.T) {
+					t.Parallel()
+
+					var output bytes.Buffer
+					if err := MarshalWithSettings(value, multipart.NewWriter(&output), format); err == nil {
+						t.Fatal("encoding unexpectedly accepted a decoded nested CRLF field name")
+					}
+					if output.Len() != 0 {
+						t.Errorf("invalid nested field wrote %d bytes before being rejected", output.Len())
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestMarshalPreservesValidMIMEHeaderValues(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		field       string
+		filename    string
+		contentType string
+	}{
+		{
+			name:        "Unicode quotes and backslashes",
+			field:       "résumé \\\"field\\\"",
+			filename:    "写真 \\\"draft\\\".txt",
+			contentType: "application/vnd.example+json; charset=\"utf-8\"",
+		},
+		{
+			name:        "horizontal tabs",
+			field:       "field\tname",
+			filename:    "upload\tname.txt",
+			contentType: "text/plain\t; charset=utf-8",
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			const contents = "streamed payload"
+			var output bytes.Buffer
+			writer := multipart.NewWriter(&output)
+			err := Marshal(map[string]any{test.field: multipartSecurityFile{
+				Reader:      strings.NewReader(contents),
+				filename:    test.filename,
+				contentType: test.contentType,
+			}}, writer)
+			if err != nil {
+				t.Fatalf("encode valid multipart values: %v", err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatalf("close multipart writer: %v", err)
+			}
+
+			reader := multipart.NewReader(&output, writer.Boundary())
+			part, err := reader.NextPart()
+			if err != nil {
+				t.Fatalf("read multipart part: %v", err)
+			}
+			if got := part.FormName(); got != test.field {
+				t.Errorf("form name = %q, want %q", got, test.field)
+			}
+			wantDisposition := fmt.Sprintf(`form-data; name="%s"; filename="%s"`,
+				escapeQuotes(test.field), escapeQuotes(test.filename))
+			if got := part.Header.Get("Content-Disposition"); got != wantDisposition {
+				t.Errorf("content disposition = %q, want %q", got, wantDisposition)
+			}
+			if got := part.Header.Get("Content-Type"); got != strings.TrimSpace(test.contentType) {
+				t.Errorf("content type = %q, want %q", got, strings.TrimSpace(test.contentType))
+			}
+			got, err := io.ReadAll(part)
+			if err != nil {
+				t.Fatalf("read multipart payload: %v", err)
+			}
+			if string(got) != contents {
+				t.Errorf("multipart payload = %q, want %q", got, contents)
+			}
+		})
+	}
+}
+
+type multipartSecurityFile struct {
+	io.Reader
+	filename    string
+	contentType string
+}
+
+func (f multipartSecurityFile) Filename() string    { return f.filename }
+func (f multipartSecurityFile) ContentType() string { return f.contentType }
+
+type multipartSecurityNamedReader struct {
+	io.Reader
+	name string
+}
+
+func (r multipartSecurityNamedReader) Name() string { return r.name }

--- a/pkg/cmd/multipartheader_test.go
+++ b/pkg/cmd/multipartheader_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openai/openai-cli/internal/apiform"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultipartRequestOptionsRejectInvalidHeadersBeforeReadingKnownLengthUploads(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		field     string
+		filename  string
+		mediaType string
+		component string
+	}{
+		{
+			name:      "field name",
+			field:     "upload\r\nX-Injected: value",
+			filename:  "valid.txt",
+			mediaType: "text/plain",
+			component: "field name",
+		},
+		{
+			name:      "filename",
+			field:     "file",
+			filename:  "upload\r\nX-Injected: value",
+			mediaType: "text/plain",
+			component: "filename",
+		},
+		{
+			name:      "content type",
+			field:     "file",
+			filename:  "valid.txt",
+			mediaType: "text/plain\r\nX-Injected: value",
+			component: "content type",
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			source := &countingReader{remaining: 7}
+			upload := &recordingReadCloser{reader: source}
+			_, err := multipartRequestOptions(map[string]any{
+				test.field: fileUpload{
+					Reader:      upload,
+					filename:    test.filename,
+					contentType: test.mediaType,
+					knownSize:   true,
+					size:        7,
+				},
+			}, apiform.FormatBrackets)
+
+			require.ErrorContains(t, err, test.component)
+			require.Zero(t, source.bytesRead.Load(), "validation must not read the upload")
+			require.Equal(t, int32(1), upload.closeCount.Load(), "validation must close the owned upload")
+		})
+	}
+}
+
+func TestMultipartRequestBodyRejectsInvalidHeadersBeforeReadingUnknownLengthUploads(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		field     string
+		filename  string
+		mediaType string
+		component string
+	}{
+		{name: "field name", field: "bad\nname", filename: "valid.txt", mediaType: "text/plain", component: "field name"},
+		{name: "filename", field: "file", filename: "bad\nname.txt", mediaType: "text/plain", component: "filename"},
+		{name: "content type", field: "file", filename: "valid.txt", mediaType: "text/plain\nbad", component: "content type"},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			source := &countingReader{remaining: 7}
+			upload := &recordingReadCloser{reader: source}
+			body := newMultipartRequestBody(map[string]any{
+				test.field: fileUpload{
+					Reader:      upload,
+					filename:    test.filename,
+					contentType: test.mediaType,
+				},
+			}, apiform.FormatBrackets)
+
+			contents, err := io.ReadAll(body)
+			require.ErrorContains(t, err, test.component)
+			require.Empty(t, contents, "invalid headers must not write multipart framing")
+			waitForMultipartBody(t, body)
+			require.Zero(t, source.bytesRead.Load(), "validation must not read the upload")
+			require.Equal(t, int32(1), upload.closeCount.Load(), "validation must close the owned upload")
+			require.NoError(t, body.Close())
+		})
+	}
+}
+
+func TestMultipartRequestOptionsRejectInvalidBufferedFieldNames(t *testing.T) {
+	t.Parallel()
+
+	_, err := multipartRequestOptions(map[string]any{
+		"outer": map[string]any{"bad\r\nX-Injected: value": "contents"},
+	}, apiform.FormatBrackets)
+	require.ErrorContains(t, err, "field name")
+}
+
+func TestFilesCreateCLIRejectsNewlineFilenameBeforeRequest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows filenames cannot contain newline characters")
+	}
+
+	path := filepath.Join(t.TempDir(), "upload\nX-Injected: value.txt")
+	require.NoError(t, os.WriteFile(path, []byte("synthetic upload"), 0o600))
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	err := runFilesCreateCLI(t.Context(), server.URL+"/", path)
+	require.ErrorContains(t, err, "invalid control character in multipart filename")
+	require.Zero(t, requests.Load(), "invalid local filenames must be rejected before any request")
+}


### PR DESCRIPTION
## Summary
- Reject invalid MIME-header control bytes in multipart field names, uploaded filenames, and content types before constructing multipart headers.
- Preserve valid Unicode, quotes, backslashes, horizontal tabs, supported public APIs, streaming, retry, content-length, and cancellation behavior.
- Add exhaustive encoder and CLI regression coverage, including nested JSON/YAML keys, every prohibited ASCII control byte, both filename interfaces, reader cleanup, unknown-length streams, and real newline-containing Unix filenames.

## Validation
- `GOCACHE=/Users/jbeckwith/.cache/openai-cli-go-build ./scripts/test -skip '^TestFilesCreateCLICancelClosesStalledFIFO$'` — all repository packages passed; Windows/amd64 tests compiled successfully.
- `GOCACHE=/Users/jbeckwith/.cache/openai-cli-go-build go test -race ./internal/apiform ./pkg/cmd -run '^(TestEncode|TestMarshal|TestMultipart|TestFilesCreateCLIRejectsNewlineFilenameBeforeRequest|TestFilesCreateCLIStreams|TestFilesCreateCLIDoesNotReplayUploads|TestImagesEditCLI|TestExactLength|TestOpenFileUpload|TestEmbedFiles)' -count=1`
- `GOCACHE=/Users/jbeckwith/.cache/openai-cli-go-build go vet ./...`
- `GOCACHE=/Users/jbeckwith/.cache/openai-cli-go-build ./scripts/lint`
- `GOCACHE=/Users/jbeckwith/.cache/openai-cli-go-build GOOS=linux GOARCH=amd64 go build ./...`

`TestFilesCreateCLICancelClosesStalledFIFO` was excluded locally because its macOS `EPIPE` assertion also fails unchanged at the original base revision; Linux CI will run the complete unfiltered suite.