### PR TITLE
ci: allow 30 minutes for GoReleaser artifact builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: ./scripts/lint
 
   build-artifacts:
-    timeout-minutes: 10
+    timeout-minutes: 30
     name: build artifacts
     permissions:
       contents: read

--- a/internal/releaseworkflow/workflow_test.go
+++ b/internal/releaseworkflow/workflow_test.go
@@ -42,6 +42,7 @@ type workflowJob struct {
 	Outputs     map[string]string `yaml:"outputs"`
 	Permissions map[string]string `yaml:"permissions"`
 	Steps       []workflowStep    `yaml:"steps"`
+	Timeout     int               `yaml:"timeout-minutes"`
 }
 
 type workflowStep struct {
@@ -501,6 +502,9 @@ func TestCISnapshotGeneratesInputsBeforeGoReleaser(t *testing.T) {
 	t.Parallel()
 
 	job := readWorkflow(t, "ci.yml").Jobs["build-artifacts"]
+	if job.Timeout != 30 {
+		t.Fatalf("CI artifact build timeout = %d minutes, want 30", job.Timeout)
+	}
 	generateIndex, generate := requireStep(t, job, "Generate release inputs")
 	installerTestIndex, _ := requireStep(t, job, "Test verified GoReleaser installer")
 	verifiedBinaryIndex, verifiedBinary := requireStep(t, job, "Set up verified GoReleaser")


### PR DESCRIPTION
## Summary

- Raise the CI artifact-build job timeout from 10 to 30 minutes so cross-platform GoReleaser builds have time to finish.
- Add a workflow regression assertion for the 30-minute budget.
- Leave unrelated CI jobs, publishing permissions, and release behavior unchanged.

## Validation

- `go test ./internal/releaseworkflow`
- `git diff --check`