### PR TITLE
fix(jsonview): avoid width underflow in static string rendering

### DIFF
--- a/internal/jsonview/staticdisplay.go
+++ b/internal/jsonview/staticdisplay.go
@@ -35,6 +35,19 @@ func formatJSON(json gjson.Result, width int) string {
 	return formatResult(json, 0, width)
 }
 
+func truncateStringToWidth(str string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if lipgloss.Width(str) <= width {
+		return str
+	}
+	if width == 1 {
+		return "…"
+	}
+	return truncate.String(str, uint(width-1)) + "…"
+}
+
 func formatResult(result gjson.Result, indent, width int) string {
 	switch result.Type {
 	case gjson.String:
@@ -42,9 +55,7 @@ func formatResult(result gjson.Result, indent, width int) string {
 		if str == "" {
 			return nullValueStyle.Render("(empty)")
 		}
-		if lipgloss.Width(str) > width {
-			str = truncate.String(str, uint(width-1)) + "…"
-		}
+		str = truncateStringToWidth(str, width)
 		return stringValueStyle.Render(str)
 	case gjson.Number:
 		return numberValueStyle.Render(result.Raw)

--- a/internal/jsonview/staticdisplay_width_test.go
+++ b/internal/jsonview/staticdisplay_width_test.go
@@ -1,0 +1,23 @@
+package jsonview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+func TestFormatResultHandlesNonPositiveStringWidth(t *testing.T) {
+	t.Parallel()
+
+	result := gjson.Parse(`"abcdef"`)
+	formatted := formatResult(result, 0, 0)
+
+	assert.NotContains(t, formatted, "abcdef")
+}
+
+func TestTruncateStringToWidthOneUsesEllipsis(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "…", truncateStringToWidth("abcdef", 1))
+}


### PR DESCRIPTION
## Summary

Avoid converting a negative remaining display width into an enormous unsigned truncation limit when rendering static JSON strings in narrow terminals.

## Problem

`formatResult` currently truncates long strings with:

```go
truncate.String(str, uint(width-1))
```

Object and array rendering can pass a non-positive `width` after subtracting the rendered key or numbering width. Converting `width-1` to `uint` then wraps the negative value to a very large number, so the string is effectively not truncated and can spill far beyond the available terminal width.

## Fix

Centralize string-width handling in a small helper that:

- returns no string content when no width is available;
- renders a single ellipsis when exactly one column is available;
- preserves strings that already fit;
- only converts a verified positive truncation width to `uint`.

Normal-width output is unchanged.

## Regression coverage

Added focused tests covering:

- a non-positive string width, which previously retained the full string because of unsigned wraparound;
- the one-column case, which now deterministically renders a single ellipsis.

## Validation

The branch is based directly on current upstream `main` (`ee92673a416c0851a5fe8907a2453db7bd450633`) and contains one signed commit touching only the static JSON renderer and its focused regression test. Full Go test execution is left to repository CI.

## Risk

Low. The behavior change is limited to string values whose available display width is zero or too small to contain the original value.

BEGIN_COMMIT_OVERRIDE
fix(jsonview): avoid width underflow in static string rendering (#117)
END_COMMIT_OVERRIDE
