### PR TITLE
fix(jsonview): preserve literal keys throughout the interactive explorer

### DIFF
--- a/internal/jsonview/explorer.go
+++ b/internal/jsonview/explorer.go
@@ -177,13 +177,14 @@ func (tv *TableView) loadMoreData(raw bool) tea.Cmd {
 
 		// For array of objects, we need to format according to columns
 		if len(tv.columns) > 1 && result.IsObject() {
+			values := result.Map()
 			newRow = make(table.Row, len(tv.columns))
 			for i, col := range tv.columns {
 				key := col.Title
 				if i < len(tv.columnKeys) {
 					key = tv.columnKeys[i]
 				}
-				newRow[i] = formatValue(result.Get(key), raw)
+				newRow[i] = formatValue(values[key], raw)
 			}
 		}
 
@@ -623,9 +624,10 @@ func newArrayOfObjectsTableView(path string, data gjson.Result, array []gjson.Re
 	rowData := make([]gjson.Result, 0, len(array))
 
 	for _, item := range array {
+		values := item.Map()
 		row := make(table.Row, len(columns))
 		for i, key := range columnKeys {
-			row[i] = formatValue(item.Get(key), raw)
+			row[i] = formatValue(values[key], raw)
 		}
 		rows = append(rows, row)
 		rowData = append(rowData, item)
@@ -646,11 +648,12 @@ func newObjectTableView(path string, data gjson.Result, raw bool) *TableView {
 	columns := []table.Column{{Title: "Object"}, {}}
 
 	keys := data.Get("@keys").Array()
+	values := data.Map()
 	rows := make([]table.Row, 0, len(keys))
 	rowData := make([]gjson.Result, 0, len(keys))
 
 	for _, key := range keys {
-		value := data.Get(key.Str)
+		value := values[key.Str]
 		title := SanitizeTerminalString(key.Str)
 		rows = append(rows, table.Row{title, formatValue(value, raw)})
 		rowData = append(rowData, value)
@@ -663,6 +666,7 @@ func newObjectTableView(path string, data gjson.Result, raw bool) *TableView {
 				columns[i].Width = max(columns[i].Width, lipgloss.Width(cell))
 			}
 		}
+
 	}
 
 	t := createTable(columns, rows, objectColor)
@@ -717,10 +721,11 @@ func formatValue(value gjson.Result, raw bool) string {
 
 func formatObject(value gjson.Result) string {
 	keys := value.Get("@keys").Array()
+	values := value.Map()
 	keyStrs := make([]string, len(keys))
 
 	for i, key := range keys {
-		val := value.Get(key.Str)
+		val := values[key.Str]
 		keyStrs[i] = formatObjectKey(SanitizeTerminalString(key.Str), val)
 	}
 

--- a/internal/jsonview/literal_keys_test.go
+++ b/internal/jsonview/literal_keys_test.go
@@ -1,0 +1,96 @@
+package jsonview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+const literalKeyFixture = `{"a.b":"literal-value","a":{"b":"nested-value"}}`
+
+func TestObjectTableUsesLiteralKeys(t *testing.T) {
+	t.Parallel()
+
+	view := newObjectTableView("", gjson.Parse(literalKeyFixture), false)
+	rows := view.table.Rows()
+
+	for _, row := range rows {
+		if row[0] == "a.b" {
+			require.Equal(t, "literal-value", row[1])
+			return
+		}
+	}
+	t.Fatal("missing literal a.b row")
+}
+
+func TestArrayOfObjectsTableUsesLiteralKeys(t *testing.T) {
+	t.Parallel()
+
+	view, err := newTableView("", gjson.Parse(`[`+literalKeyFixture+`]`), false)
+	require.NoError(t, err)
+
+	column := requireColumn(t, view, "a.b")
+	require.Equal(t, "literal-value", view.table.Rows()[0][column])
+}
+
+func TestObjectPreviewUsesLiteralKeys(t *testing.T) {
+	t.Parallel()
+
+	preview := formatValue(gjson.Parse(literalKeyFixture), false)
+	require.Contains(t, preview, `a.b:"literal-value"`)
+	require.NotContains(t, preview, `a.b:"nested-value"`)
+}
+
+func TestLazyLoadedRowsUseLiteralKeys(t *testing.T) {
+	t.Parallel()
+
+	view, err := newTableView("", gjson.Parse(`[{"a.b":"first","a":{"b":"nested-first"}}]`), false)
+	require.NoError(t, err)
+	view.Resize(80, 24)
+	view.iterator = &literalKeyIterator{items: []any{
+		map[string]any{
+			"a.b": "second",
+			"a":   map[string]any{"b": "nested-second"},
+		},
+	}}
+
+	msg := view.loadMoreData(false)()
+	require.Nil(t, msg)
+
+	column := requireColumn(t, view, "a.b")
+	rows := view.table.Rows()
+	require.Len(t, rows, 2)
+	require.Equal(t, "second", rows[1][column])
+}
+
+func requireColumn(t *testing.T, view *TableView, title string) int {
+	t.Helper()
+
+	for i, column := range view.table.Columns() {
+		if column.Title == title {
+			return i
+		}
+	}
+	t.Fatalf("missing %q column", title)
+	return -1
+}
+
+type literalKeyIterator struct {
+	items []any
+	index int
+}
+
+func (it *literalKeyIterator) Next() bool {
+	if it.index >= len(it.items) {
+		return false
+	}
+	it.index++
+	return true
+}
+
+func (it *literalKeyIterator) Err() error { return nil }
+
+func (it *literalKeyIterator) Current() any {
+	return it.items[it.index-1]
+}


### PR DESCRIPTION
## Summary

Make every interactive JSON-explorer object lookup use literal JSON member names instead of interpreting those names as GJSON path expressions.

This complements #86, which addresses the same class of bug in the static pretty renderer. The interactive explorer has its own independent lookup paths and remains affected without this change.

Related to #81.

## Problem

The explorer enumerates real object member names with `@keys`, but several rendering paths then feed those names back into `gjson.Result.Get`. `Get` parses its argument as a GJSON path, so a literal key such as `a.b` can resolve the nested path `a -> b` instead of the top-level member named exactly `a.b`.

For example:

```json
{
  "a.b": "literal-value",
  "a": {"b": "nested-value"}
}
```

can show `nested-value` under the `a.b` key even though the underlying JSON stores `literal-value` there.

The bug exists in four interactive paths:

1. ordinary object tables;
2. array-of-object tables;
3. compact object previews;
4. rows appended later by the streaming/lazy-load iterator.

Fixing only one of these leaves the same incorrect value substitution elsewhere in the explorer.

## Fix

Once keys have been enumerated, materialize each object's literal map with `Result.Map()` and index it directly by the key string. No GJSON path parsing is used for an already-known object member name.

The change covers all four interactive paths above while leaving genuine navigation-path construction and user transformations unchanged.

## Regression coverage

Added focused tests proving literal dotted keys remain distinct from nested paths in:

- object-table rendering;
- array-of-object column rendering;
- compact object previews;
- lazy-loaded streamed rows.

The fixtures deliberately contain both `"a.b"` and nested `{"a":{"b":...}}` values so a path-based lookup deterministically returns the wrong value before the fix.

## Validation

The branch is based directly on current upstream `main` (`a7719136b8ed401b0c51a05553a5e4f720150307`) and contains one DCO-signed commit. The production change is 9 additions / 4 deletions in handwritten `internal/jsonview/explorer.go`, plus focused regression coverage. Full repository test execution is left to CI.

## Risk

Low. The explorer already has the literal member names. This change only stops reinterpreting those names as query expressions. Simple keys retain the same values, while keys containing GJSON path syntax now correctly refer to their own object members.