### PR TITLE
fix(autocomplete): omit hidden flags from suggestions

### DIFF
--- a/internal/autocomplete/autocomplete.go
+++ b/internal/autocomplete/autocomplete.go
@@ -265,6 +265,9 @@ func getAllPossibleCompletions(completionStyle CompletionStyle, root *cli.Comman
 	// Completing a flag name
 	if isFlag(current) {
 		for _, flag := range cmd.Flags {
+			if vf, ok := flag.(cli.VisibleFlag); ok && !vf.IsVisible() {
+				continue
+			}
 			completions = builder.createFromFlag(current, &flag, completions)
 		}
 	}

--- a/internal/autocomplete/hidden_flags_test.go
+++ b/internal/autocomplete/hidden_flags_test.go
@@ -1,0 +1,38 @@
+package autocomplete
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+func TestFlagCompletionOmitsHiddenFlags(t *testing.T) {
+	t.Parallel()
+
+	root := &cli.Command{
+		Name: "openai",
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "visible", Aliases: []string{"v"}},
+			&cli.StringFlag{Name: "hidden", Aliases: []string{"h"}, Hidden: true},
+		},
+	}
+
+	longResult := GetCompletions(CompletionStyleZsh, root, []string{"--"})
+	longNames := completionNames(longResult.Completions)
+	require.Contains(t, longNames, "--visible")
+	require.NotContains(t, longNames, "--hidden")
+
+	shortResult := GetCompletions(CompletionStyleZsh, root, []string{"-"})
+	shortNames := completionNames(shortResult.Completions)
+	require.Contains(t, shortNames, "-v")
+	require.NotContains(t, shortNames, "-h")
+}
+
+func completionNames(completions []ShellCompletion) []string {
+	names := make([]string, 0, len(completions))
+	for _, completion := range completions {
+		names = append(names, completion.Name)
+	}
+	return names
+}


### PR DESCRIPTION
## Summary

Keep hidden/internal CLI flags out of shell-completion suggestions.

## Problem

The autocomplete code already respects `cli.VisibleFlag` when resolving an entered flag through `findFlag`, but the flag-name completion path loops over every flag in `cmd.Flags` without applying the same visibility check.

That means flags deliberately marked hidden can still be surfaced by Bash/Zsh/Fish/PowerShell completion when the user starts typing `-` or `--`.

This is separate from the existing hidden-command work: command suggestions already have their own `child.Hidden` handling, while this PR fixes flag visibility.

## Fix

Apply the same `cli.VisibleFlag` / `IsVisible()` guard used by `findFlag` before generating flag-name completions.

Visible flags and aliases keep their existing completion behavior. Flags that do not implement `cli.VisibleFlag` are also unchanged.

## Regression coverage

Added a focused synthetic-command regression with one visible and one hidden flag, each with a short alias. The test verifies both long and short visible names remain suggested while both hidden names are omitted.

## Validation

The branch is based directly on current upstream `main` (`a7719136b8ed401b0c51a05553a5e4f720150307`) and contains one DCO-signed commit. The production change is 3 lines in handwritten `internal/autocomplete/autocomplete.go`, plus focused regression coverage. Full repository test execution is left to CI.

## Risk

Low. The change only removes completion candidates for flags the CLI already marks as not visible; parsing and command execution are unchanged.