### PR TITLE
test: move certificate PEM cases out of generated tests

### DIFF
--- a/pkg/cmd/adminorganizationcertificate_custom_test.go
+++ b/pkg/cmd/adminorganizationcertificate_custom_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-cli/internal/mocktest"
+)
+
+const testCertificatePEM = `-----BEGIN CERTIFICATE-----
+MOCK-CERTIFICATE-CONTENT-FOR-OPENAI-CLI-TESTS
+THIS-IS-NOT-A-REAL-CERTIFICATE
+-----END CERTIFICATE-----`
+
+func TestAdminOrganizationCertificatesCreatePEM(t *testing.T) {
+	t.Run("regular flags", func(t *testing.T) {
+		mocktest.TestRunMockTestWithFlags(
+			t,
+			"--api-key", "string",
+			"--admin-api-key", "string",
+			"admin:organization:certificates", "create",
+			"--certificate", testCertificatePEM,
+			"--content", testCertificatePEM,
+			"--name", "name",
+		)
+	})
+
+	t.Run("piping data", func(t *testing.T) {
+		// Test piping YAML data over stdin
+		pipeData := []byte("" +
+			"certificate: |\n" +
+			"  " + strings.ReplaceAll(testCertificatePEM, "\n", "\n  ") + "\n" +
+			"content: |\n" +
+			"  " + strings.ReplaceAll(testCertificatePEM, "\n", "\n  ") + "\n" +
+			"name: name\n")
+		mocktest.TestRunMockTestWithPipeAndFlags(
+			t, pipeData,
+			"--api-key", "string",
+			"--admin-api-key", "string",
+			"admin:organization:certificates", "create",
+		)
+	})
+}

--- a/pkg/cmd/adminorganizationcertificate_test.go
+++ b/pkg/cmd/adminorganizationcertificate_test.go
@@ -3,16 +3,10 @@
 package cmd
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/openai/openai-cli/internal/mocktest"
 )
-
-const testCertificatePEM = `-----BEGIN CERTIFICATE-----
-MOCK-CERTIFICATE-CONTENT-FOR-OPENAI-CLI-TESTS
-THIS-IS-NOT-A-REAL-CERTIFICATE
------END CERTIFICATE-----`
 
 func TestAdminOrganizationCertificatesCreate(t *testing.T) {
 	t.Run("regular flags", func(t *testing.T) {
@@ -21,8 +15,7 @@ func TestAdminOrganizationCertificatesCreate(t *testing.T) {
 			"--api-key", "string",
 			"--admin-api-key", "string",
 			"admin:organization:certificates", "create",
-			"--certificate", testCertificatePEM,
-			"--content", testCertificatePEM,
+			"--certificate", "certificate",
 			"--name", "name",
 		)
 	})
@@ -30,10 +23,7 @@ func TestAdminOrganizationCertificatesCreate(t *testing.T) {
 	t.Run("piping data", func(t *testing.T) {
 		// Test piping YAML data over stdin
 		pipeData := []byte("" +
-			"certificate: |\n" +
-			"  " + strings.ReplaceAll(testCertificatePEM, "\n", "\n  ") + "\n" +
-			"content: |\n" +
-			"  " + strings.ReplaceAll(testCertificatePEM, "\n", "\n  ") + "\n" +
+			"certificate: certificate\n" +
 			"name: name\n")
 		mocktest.TestRunMockTestWithPipeAndFlags(
 			t, pipeData,


### PR DESCRIPTION
## Summary

Restore `pkg/cmd/adminorganizationcertificate_test.go` to its verified generated
contents, and move the existing handwritten PEM/content cases into
`pkg/cmd/adminorganizationcertificate_custom_test.go`.

The replacement tests are
`TestAdminOrganizationCertificatesCreatePEM/regular_flags` (multiline fake PEM
through both `--certificate` and the hidden `--content` flag) and
`TestAdminOrganizationCertificatesCreatePEM/piping_data` (the same fields as YAML
block scalars on stdin). The fixture, subtests, arguments, assertions, and test
body are unchanged except for the enclosing test's name. The ordinary generated
create examples remain covered too.

No runtime source, command behavior, dependencies, API reference, or generation
metadata changes. No compiler change or regeneration is needed.

The verified public custom-code report goes from **6 to 5 mixed files**
(`+73/-43` to `+61/-41`); the other five customizations are unchanged.

## Test Plan

- Go 1.25.11: `./scripts/format`, `./scripts/bootstrap`, `./scripts/lint`,
  `go vet ./...`, `go test ./internal/...`, and `go test ./... -run '^$'` passed.
- Command: `go test ./pkg/cmd -run '^TestAdminOrganizationCertificates(Create|CreatePEM)$' -count=1 -v`
  passed all four restored/moved cases against the pinned Steady 0.22.1 local mock.
- Command: `./scripts/test` passed, including the Windows compile check, against
  an isolated local mock. Local build/compile/full-suite commands used
  `GOFLAGS=-buildvcs=false` because this linked-worktree environment otherwise
  resolves optional VCS stamping to a non-repository parent directory.
- Exact-source comparison confirms the moved fixture and test body are identical
  except for the test name. The restored generated file has Git blob
  `145df13956f23d6bce55a0d857b678702fc4847f`, matching public generated snapshot
  `af6fa13681d98be26da62c2f835b09242c9a3beb`.
- Command: `python3 -I scripts/castiron/custom_code_report.py report --base 41936195a95f246ce1f45caf2600919394e2364b --head d12a2b9b70b78af527a4c161bfdc64913ecab760 --fetch --require-head-hash --public --out /tmp/cli-certificate-tests`
  verified both generated baselines, one removed customization, and five unchanged
  customizations.
