### PR TITLE
test: protect released large CLI payload support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,19 +99,21 @@ report exactly which checks ran.
 
 ## Large-payload compatibility
 
-Treat large payloads as a normal API contract, not evidence of malformed or
-hostile input. Responses, Chat Completions, and other APIs can legitimately
-return large `application/json` bodies and streaming events. Do not introduce
-arbitrary fixed limits on bodies, events, or lines as a security or efficiency
-fix. Prefer incremental processing, amortized-linear buffering, timely cleanup,
-and caller cancellation. Any new
-rejection limit needs an explicit, owner-approved API contract and a review of
-existing supported payloads and transports.
+Preserve large payloads supported by the last few releases. Responses, Chat
+Completions, and other APIs can legitimately return large `application/json`
+bodies and streaming events; size alone is not evidence of malformed or hostile
+input. Do not introduce arbitrary new limits on bodies, events, or lines, or
+tighten existing limits, as a security or efficiency fix. Prefer incremental
+processing, amortized-linear buffering, timely cleanup, and caller cancellation.
+Any new rejection limit needs an explicit, owner-approved API contract and a
+review of previously supported payloads and transports. This guidance does not
+remove longstanding transport limits.
 
 Protect this behavior with focused, deterministic public-entrypoint tests using
 large synthetic payloads generated in memory, not committed captures or live
 image generation. Their high memory use is intentional: do not shrink the
-payloads or raise client limits to make the tests pass. Keep coverage to the main
-JSON and streaming categories, and run large cases sequentially to keep peak
-memory reasonable. The fixture size is a regression
-probe, not a new API maximum.
+payloads or raise client limits to accommodate newly introduced caps. Keep
+coverage to the main JSON and streaming categories, and run large cases
+sequentially to keep peak memory reasonable. Respect longstanding transport
+limits when choosing fixtures; their size is a regression probe, not a new API
+maximum.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,8 @@ The checker and effective budget come from main, not the PR. Keep default CODEOW
   YAML/JSON input, pagination, and streaming as security boundaries. Preserve
   credential isolation, same-origin mutual-TLS redirects, HTTPS-proxy
   restrictions, streaming where present, cancellation, and owned-file cleanup.
-  Apply appropriate resource limits when changing paths that buffer input.
+  Preserve large API payloads when changing paths that buffer input; follow the
+  large-payload compatibility guidance below.
 - Review direct and transitive Go dependencies, `go.mod`, `go.sum`,
   `api_reference/go.mod`, module sources, `replace` directives, and checksum
   verification. Review `scripts/bootstrap`, `scripts/mock`, the pinned
@@ -95,3 +96,22 @@ The complete `./scripts/test` suite starts the npm-backed local mock server;
 review that dependency and use synthetic data before running it. Avoid
 unrelated `go.mod`/`go.sum`, generated-source, or formatting changes, and
 report exactly which checks ran.
+
+## Large-payload compatibility
+
+Treat large payloads as a normal API contract, not evidence of malformed or
+hostile input. Responses, Chat Completions, and other APIs can legitimately
+return large `application/json` bodies and streaming events. Do not introduce
+arbitrary fixed limits on bodies, events, or lines as a security or efficiency
+fix. Prefer incremental processing, amortized-linear buffering, timely cleanup,
+and caller cancellation. Any new
+rejection limit needs an explicit, owner-approved API contract and a review of
+existing supported payloads and transports.
+
+Protect this behavior with focused, deterministic public-entrypoint tests using
+large synthetic payloads generated in memory, not committed captures or live
+image generation. Their high memory use is intentional: do not shrink the
+payloads or raise client limits to make the tests pass. Keep coverage to the main
+JSON and streaming categories, and run large cases sequentially to keep peak
+memory reasonable. The fixture size is a regression
+probe, not a new API maximum.

--- a/internal/payloadtest/large_payload_test.go
+++ b/internal/payloadtest/large_payload_test.go
@@ -1,0 +1,115 @@
+package payloadtest
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestLargeResponsePayloads(t *testing.T) {
+	// High memory use is intentional. Do not shrink these synthetic payloads or
+	// raise client limits to make arbitrary caps pass. This probes compatibility,
+	// not an API maximum. Keep the cases sequential to bound peak memory.
+	payload := strings.Repeat("x", (32<<20)+1)
+	binary := filepath.Join(t.TempDir(), "openai.exe")
+	build := exec.CommandContext(t.Context(), "go", "build", "-o", binary, "./cmd/openai")
+	build.Dir = filepath.Join("..", "..")
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build CLI: %v\n%s", err, output)
+	}
+
+	for _, tc := range []struct {
+		name, command, path   string
+		contentType           string
+		prefix, suffix        string
+		textPath              string
+		finalPath, finalValue string
+		stream                bool
+	}{
+		{
+			name: "responses JSON", command: "responses", path: "/responses",
+			contentType: "application/json",
+			prefix:      `{"id":"resp_large","object":"response","status":"completed","output":[{"id":"msg_large","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"`,
+			suffix:      `","annotations":[]}]}]}`,
+			textPath:    "output.0.content.0.text",
+		},
+		{
+			name: "responses SSE", command: "responses", path: "/responses", stream: true,
+			contentType: "text/event-stream",
+			prefix:      "event: response.output_text.delta\ndata: " + `{"type":"response.output_text.delta","item_id":"msg_large","output_index":0,"content_index":0,"sequence_number":0,"delta":"`,
+			suffix: `"}` + "\n\nevent: response.completed\ndata: " +
+				`{"type":"response.completed","sequence_number":1,"response":{"id":"resp_large","object":"response","status":"completed","output":[]}}` + "\n\n",
+			textPath: "delta", finalPath: "type", finalValue: "response.completed",
+		},
+		{
+			name: "chat completions SSE", command: "chat:completions", path: "/chat/completions", stream: true,
+			contentType: "text/event-stream",
+			prefix:      `data: {"id":"chat_large","object":"chat.completion.chunk","created":0,"model":"fake-model","choices":[{"index":0,"delta":{"role":"assistant","content":"`,
+			suffix: `"},"finish_reason":null}]}` + "\n\ndata: " +
+				`{"id":"chat_large","object":"chat.completion.chunk","created":0,"model":"fake-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\ndata: [DONE]\n\n",
+			textPath: "choices.0.delta.content", finalPath: "choices.0.finish_reason", finalValue: "stop",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != tc.path {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					http.Error(w, "unexpected request", http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", tc.contentType)
+				io.WriteString(w, tc.prefix)
+				io.WriteString(w, payload)
+				io.WriteString(w, tc.suffix)
+			}))
+			defer server.Close()
+
+			args := []string{"--base-url", server.URL, "--format", "jsonl", tc.command, "create", "--model", "fake-model"}
+			if tc.command == "chat:completions" {
+				args = append(args, "--message", `{"role":"user","content":"synthetic input"}`)
+			} else {
+				args = append(args, "--input", "synthetic input")
+			}
+			if tc.stream {
+				args = append(args, "--stream=true")
+			}
+			command := exec.CommandContext(t.Context(), binary, args...)
+			// Do not inherit real credentials, endpoint overrides, or mTLS settings.
+			command.Env = []string{"OPENAI_API_KEY=sk-fake-payload-test", "FORCE_COLOR=0"}
+			var stderr bytes.Buffer
+			command.Stderr = &stderr
+			output, err := command.Output()
+			if err != nil {
+				t.Fatalf("CLI failed: %v\n%s", err, &stderr)
+			}
+
+			decoder := json.NewDecoder(bytes.NewReader(output))
+			var item json.RawMessage
+			if err := decoder.Decode(&item); err != nil {
+				t.Fatalf("decode CLI output: %v", err)
+			}
+			if got := gjson.GetBytes(item, tc.textPath).String(); got != payload {
+				t.Fatalf("output text was not preserved: got %d bytes, want %d", len(got), len(payload))
+			}
+			if tc.stream {
+				if err := decoder.Decode(&item); err != nil {
+					t.Fatalf("decode event after large event: %v", err)
+				}
+				if got := gjson.GetBytes(item, tc.finalPath).String(); got != tc.finalValue {
+					t.Fatalf("final event: got %q, want %q", got, tc.finalValue)
+				}
+			}
+			if err := decoder.Decode(&item); err != io.EOF {
+				t.Fatalf("expected end of output, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/payloadtest/large_payload_test.go
+++ b/internal/payloadtest/large_payload_test.go
@@ -16,8 +16,8 @@ import (
 
 func TestLargeResponsePayloads(t *testing.T) {
 	// High memory use is intentional. Do not shrink these synthetic payloads or
-	// raise client limits to make arbitrary caps pass. This probes compatibility,
-	// not an API maximum. Keep the cases sequential to bound peak memory.
+	// raise client limits to accommodate newly introduced caps. These probes
+	// protect released behavior, not a new API maximum. Keep the cases sequential.
 	payload := strings.Repeat("x", (32<<20)+1)
 	binary := filepath.Join(t.TempDir(), "openai.exe")
 	build := exec.CommandContext(t.Context(), "go", "build", "-o", binary, "./cmd/openai")
@@ -59,6 +59,12 @@ func TestLargeResponsePayloads(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			text := payload
+			if tc.stream {
+				// Preserve the Go SDK's longstanding 32 MiB SSE line limit, leaving
+				// room for the JSON envelope. This test does not relax that limit.
+				text = text[:(32<<20)-1024]
+			}
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost || r.URL.Path != tc.path {
 					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -67,7 +73,7 @@ func TestLargeResponsePayloads(t *testing.T) {
 				}
 				w.Header().Set("Content-Type", tc.contentType)
 				io.WriteString(w, tc.prefix)
-				io.WriteString(w, payload)
+				io.WriteString(w, text)
 				io.WriteString(w, tc.suffix)
 			}))
 			defer server.Close()
@@ -96,8 +102,8 @@ func TestLargeResponsePayloads(t *testing.T) {
 			if err := decoder.Decode(&item); err != nil {
 				t.Fatalf("decode CLI output: %v", err)
 			}
-			if got := gjson.GetBytes(item, tc.textPath).String(); got != payload {
-				t.Fatalf("output text was not preserved: got %d bytes, want %d", len(got), len(payload))
+			if got := gjson.GetBytes(item, tc.textPath).String(); got != text {
+				t.Fatalf("output text was not preserved: got %d bytes, want %d", len(got), len(text))
 			}
 			if tc.stream {
 				if err := decoder.Decode(&item); err != nil {


### PR DESCRIPTION
## Summary

Protect large Responses and Chat Completions payloads accepted by recent CLI releases from future accidental tightening, following the compatibility guidance in [openai-node#2433](https://github.com/openai/openai-node/pull/2433).

Add three sequential, offline tests that build and invoke the real CLI: a blocking Responses JSON body containing 32 MiB + 1 byte of `output_text`, a large Responses SSE text delta, and a large Chat Completions SSE content delta. Assert exact text preservation and continued delivery of the following streaming event. Fixtures are generated in memory, use a local HTTP server and fake credentials, and never become committed recordings.

The SSE probes leave 1 KiB of envelope headroom below the Go SDK's longstanding line cap ([introduced in openai-go#403](https://github.com/openai/openai-[go/pull/403](https://www.golinks.io/pull/403?trackSource=github)) and [raised to 32 MiB in #442](https://github.com/openai/openai-[go/pull/442](https://www.golinks.io/pull/442?trackSource=github))). This PR protects released behavior without removing that limit or changing the Go SDK dependency. Add agent guidance explaining the intentionally high memory use and prohibiting smaller fixtures or newly tightened caps from hiding regressions.
