### PR TITLE
fix: Add provenance-aware untrusted stdin mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ For details about specific commands, use the `--help` flag.
 | `OPENAI_WEBHOOK_SECRET` | no | `null` |
 | `OPENAI_MTLS_CLIENT_CERT_FILE` | no | `null` |
 | `OPENAI_MTLS_CLIENT_KEY_FILE` | no | `null` |
+| `OPENAI_UNTRUSTED_STDIN` | no | `false` |
 
 ### Global flags
 
@@ -151,6 +152,20 @@ arg:
   image: "@abe.jpg"
 YAML
 ```
+
+When piping JSON or YAML from an untrusted source, enable untrusted-stdin mode:
+
+```bash
+untrusted-producer | OPENAI_UNTRUSTED_STDIN=1 openai <command> --file ./upload.txt
+```
+
+In this mode, values supplied through stdin are treated as literal data: `@`,
+`@file://`, and `@data://` references in request bodies, headers, and query
+parameters do not read local files. File-upload parameters must be provided
+explicitly as command-line flags. Explicit flags retain their normal file
+behavior and take precedence over values supplied through stdin. Leave
+`OPENAI_UNTRUSTED_STDIN` unset when using trusted heredocs or other trusted
+piped input that intentionally references local files.
 
 If you need to pass a string literal that begins with an `@` sign, you can
 escape the `@` sign to avoid accidentally passing a file.

--- a/internal/requestflag/requestflag.go
+++ b/internal/requestflag/requestflag.go
@@ -135,16 +135,7 @@ type RequestContents struct {
 	Body    any
 }
 
-// ApplyStdinDataToFlags sets flag values from a parsed stdin data map for flags that have not already been
-// set via the command line. This allows piped YAML/JSON data to satisfy path, query, and header parameters.
-// Body parameters are excluded: they are already handled by the maps.Copy merge in flagOptions.
-// For each unset flag, if the parsed data map contains a key matching the flag's QueryPath, HeaderPath, or
-// PathParam (or any of its DataAliases), the flag is set to that value via flag.Set.
-//
-// Inner flags (those with an outer flag) are also handled: if the outer flag's body path key exists in the
-// data map and contains a nested map with a key matching the inner flag's field (or aliases), the inner
-// flag is set from that nested value.
-func ApplyStdinDataToFlags(cmd *cli.Command, data map[string]any) error {
+func applyStdinDataToFlags(cmd *cli.Command, data map[string]any, onSet func(cli.Flag)) error {
 	for _, flag := range cmd.Flags {
 		if flag.IsSet() {
 			continue
@@ -179,8 +170,8 @@ func ApplyStdinDataToFlags(cmd *cli.Command, data map[string]any) error {
 			if err != nil {
 				return fmt.Errorf("cannot format piped value for flag %q: %w", flag.Names()[0], err)
 			}
-			if err := flag.Set(flag.Names()[0], setVal); err != nil {
-				return fmt.Errorf("cannot set flag %q from piped data: %w", flag.Names()[0], err)
+			if err := setFlagFromStdin(flag, setVal, onSet); err != nil {
+				return err
 			}
 			continue
 		}
@@ -211,8 +202,8 @@ func ApplyStdinDataToFlags(cmd *cli.Command, data map[string]any) error {
 			if err != nil {
 				return fmt.Errorf("cannot format piped value for flag %q: %w", flag.Names()[0], err)
 			}
-			if err := flag.Set(flag.Names()[0], setVal); err != nil {
-				return fmt.Errorf("cannot set flag %q from piped data: %w", flag.Names()[0], err)
+			if err := setFlagFromStdin(flag, setVal, onSet); err != nil {
+				return err
 			}
 			break
 		}

--- a/internal/requestflag/requestflag.go
+++ b/internal/requestflag/requestflag.go
@@ -166,7 +166,7 @@ func applyStdinDataToFlags(cmd *cli.Command, data map[string]any, onSet func(cli
 			if !found {
 				continue
 			}
-			if innerMapFieldIsSet(inner) {
+			if innerFieldIsSet(inner) {
 				continue
 			}
 			setVal, err := formatForFlagSet(val)

--- a/internal/requestflag/requestflag.go
+++ b/internal/requestflag/requestflag.go
@@ -166,6 +166,9 @@ func applyStdinDataToFlags(cmd *cli.Command, data map[string]any, onSet func(cli
 			if !found {
 				continue
 			}
+			if innerMapFieldIsSet(inner) {
+				continue
+			}
 			setVal, err := formatForFlagSet(val)
 			if err != nil {
 				return fmt.Errorf("cannot format piped value for flag %q: %w", flag.Names()[0], err)

--- a/internal/requestflag/stdinprovenance.go
+++ b/internal/requestflag/stdinprovenance.go
@@ -30,17 +30,20 @@ func innerFieldIsSet(inner HasOuterFlag) bool {
 	field := inner.GetInnerField()
 	switch values := outer.Get().(type) {
 	case map[string]any:
+		if len(values) == 0 {
+			return true
+		}
 		_, exists := values[field]
 		return exists
 	case []map[string]any:
 		if len(values) == 0 {
-			return false
+			return true
 		}
 		_, exists := values[len(values)-1][field]
 		return exists
 	case []any:
 		if len(values) == 0 {
-			return false
+			return true
 		}
 		last, ok := values[len(values)-1].(map[string]any)
 		if !ok {

--- a/internal/requestflag/stdinprovenance.go
+++ b/internal/requestflag/stdinprovenance.go
@@ -22,6 +22,19 @@ func ApplyStdinDataToFlagsWithProvenance(cmd *cli.Command, data map[string]any, 
 	return applyStdinDataToFlags(cmd, data, onSet)
 }
 
+func innerMapFieldIsSet(inner HasOuterFlag) bool {
+	outer := inner.GetOuterFlag()
+	if !outer.IsSet() {
+		return false
+	}
+	values, ok := outer.Get().(map[string]any)
+	if !ok {
+		return false
+	}
+	_, exists := values[inner.GetInnerField()]
+	return exists
+}
+
 func setFlagFromStdin(flag cli.Flag, value string, onSet func(cli.Flag)) error {
 	if err := flag.Set(flag.Names()[0], value); err != nil {
 		return fmt.Errorf("cannot set flag %q from piped data: %w", flag.Names()[0], err)

--- a/internal/requestflag/stdinprovenance.go
+++ b/internal/requestflag/stdinprovenance.go
@@ -22,17 +22,34 @@ func ApplyStdinDataToFlagsWithProvenance(cmd *cli.Command, data map[string]any, 
 	return applyStdinDataToFlags(cmd, data, onSet)
 }
 
-func innerMapFieldIsSet(inner HasOuterFlag) bool {
+func innerFieldIsSet(inner HasOuterFlag) bool {
 	outer := inner.GetOuterFlag()
 	if !outer.IsSet() {
 		return false
 	}
-	values, ok := outer.Get().(map[string]any)
-	if !ok {
-		return false
+	field := inner.GetInnerField()
+	switch values := outer.Get().(type) {
+	case map[string]any:
+		_, exists := values[field]
+		return exists
+	case []map[string]any:
+		if len(values) == 0 {
+			return false
+		}
+		_, exists := values[len(values)-1][field]
+		return exists
+	case []any:
+		if len(values) == 0 {
+			return false
+		}
+		last, ok := values[len(values)-1].(map[string]any)
+		if !ok {
+			return false
+		}
+		_, exists := last[field]
+		return exists
 	}
-	_, exists := values[inner.GetInnerField()]
-	return exists
+	return false
 }
 
 func setFlagFromStdin(flag cli.Flag, value string, onSet func(cli.Flag)) error {

--- a/internal/requestflag/stdinprovenance.go
+++ b/internal/requestflag/stdinprovenance.go
@@ -1,0 +1,33 @@
+package requestflag
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v3"
+)
+
+// ApplyStdinDataToFlags sets flag values from a parsed stdin data map for flags
+// that have not already been set via the command line. This allows piped
+// YAML/JSON data to satisfy path, query, and header parameters. Body parameters
+// are excluded because they are merged separately. Request locations and inner
+// flags are matched by their canonical names or configured data aliases.
+func ApplyStdinDataToFlags(cmd *cli.Command, data map[string]any) error {
+	return applyStdinDataToFlags(cmd, data, nil)
+}
+
+// ApplyStdinDataToFlagsWithProvenance reports every flag populated from stdin.
+// Inner flags are reported directly so callers can distinguish an untrusted
+// nested field from other, explicitly supplied fields on its outer flag.
+func ApplyStdinDataToFlagsWithProvenance(cmd *cli.Command, data map[string]any, onSet func(cli.Flag)) error {
+	return applyStdinDataToFlags(cmd, data, onSet)
+}
+
+func setFlagFromStdin(flag cli.Flag, value string, onSet func(cli.Flag)) error {
+	if err := flag.Set(flag.Names()[0], value); err != nil {
+		return fmt.Errorf("cannot set flag %q from piped data: %w", flag.Names()[0], err)
+	}
+	if onSet != nil {
+		onSet(flag)
+	}
+	return nil
+}

--- a/internal/requestflag/stdinprovenance_test.go
+++ b/internal/requestflag/stdinprovenance_test.go
@@ -108,3 +108,53 @@ func TestApplyStdinDataToFlagsWithProvenancePreservesExplicitInnerArrayField(t *
 	require.Equal(t, []map[string]any{{"value": "explicit"}}, outer.Get())
 	require.False(t, observed)
 }
+
+func TestApplyStdinDataToFlagsWithProvenancePreservesExplicitEmptyCollections(t *testing.T) {
+	t.Parallel()
+
+	mapOuter := &Flag[map[string]any]{Name: "nested", BodyPath: "nested"}
+	arrayOuter := &Flag[any]{Name: "nested", BodyPath: "nested"}
+	tests := []struct {
+		name     string
+		outer    cli.Flag
+		inner    HasOuterFlag
+		rawValue string
+		expected any
+	}{
+		{
+			name:     "map",
+			outer:    mapOuter,
+			inner:    &InnerFlag[string]{Name: "nested.value", InnerField: "value", OuterFlag: mapOuter},
+			rawValue: `{}`,
+			expected: map[string]any{},
+		},
+		{
+			name:     "untyped array",
+			outer:    arrayOuter,
+			inner:    &InnerFlag[string]{Name: "nested.value", InnerField: "value", OuterFlag: arrayOuter, OuterIsArrayOfObjects: true},
+			rawValue: `[]`,
+			expected: []any{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.NoError(t, test.outer.PreParse())
+			require.NoError(t, test.outer.Set("nested", test.rawValue))
+			command := &cli.Command{Flags: []cli.Flag{test.outer, test.inner}}
+			observed := false
+
+			err := ApplyStdinDataToFlagsWithProvenance(command, map[string]any{
+				"nested": map[string]any{"value": "piped"},
+			}, func(cli.Flag) {
+				observed = true
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, test.expected, test.outer.Get())
+			require.False(t, observed)
+		})
+	}
+}

--- a/internal/requestflag/stdinprovenance_test.go
+++ b/internal/requestflag/stdinprovenance_test.go
@@ -82,3 +82,29 @@ func TestApplyStdinDataToFlagsWithProvenancePreservesExplicitInnerMapField(t *te
 	require.Equal(t, "explicit", outer.Get().(map[string]any)["value"])
 	require.False(t, observed)
 }
+
+func TestApplyStdinDataToFlagsWithProvenancePreservesExplicitInnerArrayField(t *testing.T) {
+	t.Parallel()
+
+	outer := &Flag[[]map[string]any]{Name: "entries", BodyPath: "entries"}
+	inner := &InnerFlag[string]{
+		Name:                  "entries.value",
+		InnerField:            "value",
+		OuterFlag:             outer,
+		OuterIsArrayOfObjects: true,
+	}
+	require.NoError(t, outer.PreParse())
+	require.NoError(t, inner.Set("entries.value", "explicit"))
+	command := &cli.Command{Flags: []cli.Flag{outer, inner}}
+	observed := false
+
+	err := ApplyStdinDataToFlagsWithProvenance(command, map[string]any{
+		"entries": map[string]any{"value": "piped"},
+	}, func(cli.Flag) {
+		observed = true
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"value": "explicit"}}, outer.Get())
+	require.False(t, observed)
+}

--- a/internal/requestflag/stdinprovenance_test.go
+++ b/internal/requestflag/stdinprovenance_test.go
@@ -1,0 +1,59 @@
+package requestflag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+func TestApplyStdinDataToFlagsWithProvenance(t *testing.T) {
+	t.Parallel()
+
+	query := &Flag[string]{Name: "query", QueryPath: "query", DataAliases: []string{"query_alias"}}
+	header := &Flag[string]{Name: "header", HeaderPath: "X-Test"}
+	explicit := &Flag[string]{Name: "explicit", QueryPath: "explicit"}
+	outer := &Flag[map[string]any]{Name: "nested", BodyPath: "nested"}
+	inner := &InnerFlag[string]{
+		Name:        "nested.value",
+		InnerField:  "value",
+		DataAliases: []string{"value_alias"},
+		OuterFlag:   outer,
+	}
+	for _, flag := range []*Flag[string]{query, header, explicit} {
+		require.NoError(t, flag.PreParse())
+	}
+	require.NoError(t, outer.PreParse())
+	require.NoError(t, explicit.Set("explicit", "trusted"))
+
+	command := &cli.Command{Flags: []cli.Flag{query, header, explicit, outer, inner}}
+	var observed []cli.Flag
+	err := ApplyStdinDataToFlagsWithProvenance(command, map[string]any{
+		"query_alias": "piped query",
+		"X-Test":      "piped header",
+		"explicit":    "piped override",
+		"nested":      map[string]any{"value_alias": "piped nested value"},
+	}, func(flag cli.Flag) {
+		observed = append(observed, flag)
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []cli.Flag{query, header, inner}, observed)
+	require.Equal(t, "trusted", explicit.Get())
+}
+
+func TestApplyStdinDataToFlagsWithProvenanceDoesNotReportFailedSet(t *testing.T) {
+	t.Parallel()
+
+	flag := &Flag[int64]{Name: "count", QueryPath: "count"}
+	require.NoError(t, flag.PreParse())
+	command := &cli.Command{Flags: []cli.Flag{flag}}
+	observed := false
+
+	err := ApplyStdinDataToFlagsWithProvenance(command, map[string]any{"count": "not an integer"}, func(cli.Flag) {
+		observed = true
+	})
+
+	require.Error(t, err)
+	require.False(t, observed)
+}

--- a/internal/requestflag/stdinprovenance_test.go
+++ b/internal/requestflag/stdinprovenance_test.go
@@ -57,3 +57,28 @@ func TestApplyStdinDataToFlagsWithProvenanceDoesNotReportFailedSet(t *testing.T)
 	require.Error(t, err)
 	require.False(t, observed)
 }
+
+func TestApplyStdinDataToFlagsWithProvenancePreservesExplicitInnerMapField(t *testing.T) {
+	t.Parallel()
+
+	outer := &Flag[map[string]any]{Name: "nested", BodyPath: "nested"}
+	inner := &InnerFlag[string]{
+		Name:       "nested.value",
+		InnerField: "value",
+		OuterFlag:  outer,
+	}
+	require.NoError(t, outer.PreParse())
+	require.NoError(t, inner.Set("nested.value", "explicit"))
+	command := &cli.Command{Flags: []cli.Flag{outer, inner}}
+	observed := false
+
+	err := ApplyStdinDataToFlagsWithProvenance(command, map[string]any{
+		"nested": map[string]any{"value": "piped"},
+	}, func(cli.Flag) {
+		observed = true
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "explicit", outer.Get().(map[string]any)["value"])
+	require.False(t, observed)
+}

--- a/pkg/cmd/flagoptions.go
+++ b/pkg/cmd/flagoptions.go
@@ -141,6 +141,10 @@ func embedFilesValue(v reflect.Value, embedStyle FileEmbedStyle, stdin *onceStdi
 		return result, nil
 
 	case reflect.String:
+		if v.Type() == reflect.TypeOf(untrustedStdinValue("")) {
+			return reflect.ValueOf(v.String()), nil
+		}
+
 		// FilePathValue is always treated as a file path without needing the "@" prefix.
 		// These only appear on binary upload parameters (multipart/octet-stream), which
 		// always use EmbedIOReader.
@@ -323,6 +327,11 @@ func flagOptions(
 	// "-". In this case, we won't attempt to read it as a JSON/YAML blob for options setting.
 	ignoreStdin bool,
 ) (options []option.RequestOption, err error) {
+	stdinSecurity, err := newStdinSecurity()
+	if err != nil {
+		return nil, err
+	}
+
 	// Once multipart files have been opened, close them on every error path
 	// until ownership is transferred to multipartRequestBody below.
 	var pendingMultipartUploads any
@@ -361,11 +370,15 @@ func flagOptions(
 				applyDataAliases(cmd, bodyMap)
 				// Apply any matching keys from the piped data to path, query, and header flags
 				// that have not already been set via the command line.
-				if err := requestflag.ApplyStdinDataToFlags(cmd, bodyMap); err != nil {
+				if err := requestflag.ApplyStdinDataToFlagsWithProvenance(cmd, bodyMap, stdinSecurity.recordFlag); err != nil {
 					return nil, err
 				}
 				// Re-extract request contents now that flags may have been updated.
 				requestContents = requestflag.ExtractRequestContents(cmd)
+				stdinSecurity.protectFlagValues(&requestContents)
+				if stdinSecurity.enabled {
+					bodyMap = protectStdinValue(bodyMap).(map[string]any)
+				}
 				// Remove keys that were consumed as query, header, or path params so they
 				// don't also leak into the request body via the maps.Copy merge below.
 				// We delete both the canonical key and any aliases since the user may have
@@ -393,6 +406,9 @@ func flagOptions(
 					}
 				}
 			} else if bodyType != EmptyBody {
+				if stdinSecurity.enabled {
+					bodyData = protectStdinValue(bodyData)
+				}
 				if flagMap, ok := requestContents.Body.(map[string]any); ok && len(flagMap) > 0 {
 					return nil, fmt.Errorf("Cannot merge flags with a body that is not a map: %v", bodyData)
 				} else {
@@ -415,10 +431,11 @@ func flagOptions(
 	}
 
 	// For flags marked as FileInput (type: string, format: binary), the value is always
-	// a file path. Wrap with FilePathValue so embedFiles reads the file automatically
-	// without requiring the user to type the "@" prefix. This handles both values set
-	// via explicit CLI flags and values that arrived via piped YAML/JSON data.
-	wrapFileInputValues(cmd, &requestContents)
+	// A FileInput value is a file path, so wrap trusted values with FilePathValue
+	// for automatic expansion. In untrusted-stdin mode, reject piped file paths.
+	if err := wrapFileInputValues(cmd, &requestContents); err != nil {
+		return nil, err
+	}
 
 	// Determine stdin availability for FileInput params that use "-".
 	var stdinReader onceStdinReader
@@ -590,9 +607,9 @@ func rewriteAliases(m map[string]any, canonical string, aliases []string) {
 
 // wrapFileInputValues replaces string values for FileInput flags (type: string, format: binary) with
 // FilePathValue sentinel values. embedFilesValue recognizes FilePathValue and reads the file contents
-// directly, so the user doesn't need to type the "@" prefix. This handles both values set via explicit
-// CLI flags and values that arrived via piped YAML/JSON data.
-func wrapFileInputValues(cmd *cli.Command, contents *requestflag.RequestContents) {
+// directly, so the user doesn't need to type the "@" prefix. Untrusted piped
+// file paths are rejected before any file can be opened.
+func wrapFileInputValues(cmd *cli.Command, contents *requestflag.RequestContents) error {
 	bodyMap, _ := contents.Body.(map[string]any)
 
 	for _, flag := range cmd.Flags {
@@ -601,30 +618,27 @@ func wrapFileInputValues(cmd *cli.Command, contents *requestflag.RequestContents
 			continue
 		}
 
-		// Wrap values set via explicit CLI flags.
-		if flag.IsSet() {
-			if wrapped, changed := wrapFileInputValue(flag.Get()); changed {
-				if bodyPath := inReq.GetBodyPath(); bodyPath != "" {
-					if bodyMap != nil {
-						bodyMap[bodyPath] = wrapped
-					}
-				} else if queryPath := inReq.GetQueryPath(); queryPath != "" {
-					contents.Queries[queryPath] = wrapped
-				} else if headerPath := inReq.GetHeaderPath(); headerPath != "" {
-					contents.Headers[headerPath] = wrapped
-				}
-			}
+		var values map[string]any
+		var path string
+		if path = inReq.GetBodyPath(); path != "" {
+			values = bodyMap
+		} else if path = inReq.GetQueryPath(); path != "" {
+			values = contents.Queries
+		} else if path = inReq.GetHeaderPath(); path != "" {
+			values = contents.Headers
 		}
-
-		// Wrap values that arrived via piped YAML/JSON data in the body map.
-		if bodyPath := inReq.GetBodyPath(); bodyPath != "" && bodyMap != nil {
-			if value, exists := bodyMap[bodyPath]; exists {
-				if wrapped, changed := wrapFileInputValue(value); changed {
-					bodyMap[bodyPath] = wrapped
-				}
-			}
+		value, exists := values[path]
+		if !exists {
+			continue
+		}
+		if containsUntrustedStdinValue(value) {
+			return fmt.Errorf("file input %q from piped YAML/JSON is disabled when %s is enabled; provide --%s explicitly", path, untrustedStdinEnv, flag.Names()[0])
+		}
+		if wrapped, changed := wrapFileInputValue(value); changed {
+			values[path] = wrapped
 		}
 	}
+	return nil
 }
 
 func wrapFileInputValue(value any) (any, bool) {

--- a/pkg/cmd/flagoptions.go
+++ b/pkg/cmd/flagoptions.go
@@ -368,6 +368,7 @@ func flagOptions(
 			}
 			if bodyMap, ok := bodyData.(map[string]any); ok {
 				applyDataAliases(cmd, bodyMap)
+				stdinSecurity.recordBodyFlags(cmd, bodyMap)
 				// Apply any matching keys from the piped data to path, query, and header flags
 				// that have not already been set via the command line.
 				if err := requestflag.ApplyStdinDataToFlagsWithProvenance(cmd, bodyMap, stdinSecurity.recordFlag); err != nil {
@@ -430,10 +431,9 @@ func flagOptions(
 		}
 	}
 
-	// For flags marked as FileInput (type: string, format: binary), the value is always
-	// A FileInput value is a file path, so wrap trusted values with FilePathValue
-	// for automatic expansion. In untrusted-stdin mode, reject piped file paths.
-	if err := wrapFileInputValues(cmd, &requestContents); err != nil {
+	// FileInput values are file paths, so wrap trusted values with FilePathValue
+	// for automatic expansion. In untrusted-stdin mode, reject piped values.
+	if err := wrapFileInputValues(cmd, &requestContents, stdinSecurity); err != nil {
 		return nil, err
 	}
 
@@ -609,7 +609,7 @@ func rewriteAliases(m map[string]any, canonical string, aliases []string) {
 // FilePathValue sentinel values. embedFilesValue recognizes FilePathValue and reads the file contents
 // directly, so the user doesn't need to type the "@" prefix. Untrusted piped
 // file paths are rejected before any file can be opened.
-func wrapFileInputValues(cmd *cli.Command, contents *requestflag.RequestContents) error {
+func wrapFileInputValues(cmd *cli.Command, contents *requestflag.RequestContents, stdinSecurity *stdinSecurity) error {
 	bodyMap, _ := contents.Body.(map[string]any)
 
 	for _, flag := range cmd.Flags {
@@ -631,7 +631,7 @@ func wrapFileInputValues(cmd *cli.Command, contents *requestflag.RequestContents
 		if !exists {
 			continue
 		}
-		if containsUntrustedStdinValue(value) {
+		if stdinSecurity.fileInputFromStdin(flag) {
 			return fmt.Errorf("file input %q from piped YAML/JSON is disabled when %s is enabled; provide --%s explicitly", path, untrustedStdinEnv, flag.Names()[0])
 		}
 		if wrapped, changed := wrapFileInputValue(value); changed {

--- a/pkg/cmd/stdinsecurity.go
+++ b/pkg/cmd/stdinsecurity.go
@@ -131,7 +131,7 @@ func protectStdinValue(value any) any {
 func containsUntrustedStdinValue(value any) bool {
 	switch value := value.(type) {
 	case untrustedStdinValue:
-		return value != ""
+		return true
 	case []any:
 		for _, element := range value {
 			if containsUntrustedStdinValue(element) {

--- a/pkg/cmd/stdinsecurity.go
+++ b/pkg/cmd/stdinsecurity.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/openai/openai-cli/internal/requestflag"
+	"github.com/urfave/cli/v3"
+)
+
+const untrustedStdinEnv = "OPENAI_UNTRUSTED_STDIN"
+
+// untrustedStdinValue preserves a string's origin until the shared file
+// expansion boundary, where its contents are always interpreted literally.
+type untrustedStdinValue string
+
+type stdinSecurity struct {
+	enabled bool
+	flags   map[cli.Flag]struct{}
+}
+
+func newStdinSecurity() (*stdinSecurity, error) {
+	value, exists := os.LookupEnv(untrustedStdinEnv)
+	if !exists {
+		return &stdinSecurity{}, nil
+	}
+	enabled, err := strconv.ParseBool(value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s value %q: expected a boolean", untrustedStdinEnv, value)
+	}
+	return &stdinSecurity{enabled: enabled}, nil
+}
+
+func (s *stdinSecurity) recordFlag(flag cli.Flag) {
+	if !s.enabled {
+		return
+	}
+	if inner, ok := flag.(requestflag.HasOuterFlag); ok {
+		protectInnerFlagValue(inner)
+		return
+	}
+	if s.flags == nil {
+		s.flags = make(map[cli.Flag]struct{})
+	}
+	s.flags[flag] = struct{}{}
+}
+
+func (s *stdinSecurity) protectFlagValues(contents *requestflag.RequestContents) {
+	if !s.enabled {
+		return
+	}
+	body, _ := contents.Body.(map[string]any)
+	for flag := range s.flags {
+		inRequest, ok := flag.(requestflag.InRequest)
+		if !ok {
+			continue
+		}
+		protectRequestValue(contents.Queries, inRequest.GetQueryPath())
+		protectRequestValue(contents.Headers, inRequest.GetHeaderPath())
+		if inRequest.IsBodyRoot() {
+			contents.Body = protectStdinValue(contents.Body)
+		} else {
+			protectRequestValue(body, inRequest.GetBodyPath())
+		}
+	}
+}
+
+func protectInnerFlagValue(inner requestflag.HasOuterFlag) {
+	switch outer := inner.GetOuterFlag().Get().(type) {
+	case map[string]any:
+		protectRequestValue(outer, inner.GetInnerField())
+	case []map[string]any:
+		if len(outer) > 0 {
+			protectRequestValue(outer[len(outer)-1], inner.GetInnerField())
+		}
+	case []any:
+		if len(outer) > 0 {
+			if nested, ok := outer[len(outer)-1].(map[string]any); ok {
+				protectRequestValue(nested, inner.GetInnerField())
+			}
+		}
+	}
+}
+
+func protectRequestValue(values map[string]any, path string) {
+	if path == "" {
+		return
+	}
+	if value, exists := values[path]; exists {
+		values[path] = protectStdinValue(value)
+	}
+}
+
+func protectStdinValue(value any) any {
+	switch value := value.(type) {
+	case string:
+		return untrustedStdinValue(value)
+	case *string:
+		if value != nil {
+			return untrustedStdinValue(*value)
+		}
+	case map[string]any:
+		result := make(map[string]any, len(value))
+		for key, element := range value {
+			result[key] = protectStdinValue(element)
+		}
+		return result
+	case []any:
+		result := make([]any, len(value))
+		for index, element := range value {
+			result[index] = protectStdinValue(element)
+		}
+		return result
+	case []string:
+		result := make([]any, len(value))
+		for index, element := range value {
+			result[index] = untrustedStdinValue(element)
+		}
+		return result
+	case []map[string]any:
+		result := make([]any, len(value))
+		for index, element := range value {
+			result[index] = protectStdinValue(element)
+		}
+		return result
+	}
+	return value
+}
+
+func containsUntrustedStdinValue(value any) bool {
+	switch value := value.(type) {
+	case untrustedStdinValue:
+		return value != ""
+	case []any:
+		for _, element := range value {
+			if containsUntrustedStdinValue(element) {
+				return true
+			}
+		}
+	case map[string]any:
+		for _, element := range value {
+			if containsUntrustedStdinValue(element) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/cmd/stdinsecurity.go
+++ b/pkg/cmd/stdinsecurity.go
@@ -16,8 +16,8 @@ const untrustedStdinEnv = "OPENAI_UNTRUSTED_STDIN"
 type untrustedStdinValue string
 
 type stdinSecurity struct {
-	enabled bool
-	flags   map[cli.Flag]struct{}
+	enabled    bool
+	stdinFlags map[cli.Flag]struct{}
 }
 
 func newStdinSecurity() (*stdinSecurity, error) {
@@ -36,14 +36,37 @@ func (s *stdinSecurity) recordFlag(flag cli.Flag) {
 	if !s.enabled {
 		return
 	}
+	if s.stdinFlags == nil {
+		s.stdinFlags = make(map[cli.Flag]struct{})
+	}
+	s.stdinFlags[flag] = struct{}{}
 	if inner, ok := flag.(requestflag.HasOuterFlag); ok {
 		protectInnerFlagValue(inner)
+	}
+}
+
+func (s *stdinSecurity) recordBodyFlags(cmd *cli.Command, data map[string]any) {
+	if !s.enabled {
 		return
 	}
-	if s.flags == nil {
-		s.flags = make(map[cli.Flag]struct{})
+	for _, flag := range cmd.Flags {
+		inRequest, ok := flag.(requestflag.InRequest)
+		if !ok || flag.IsSet() {
+			continue
+		}
+		bodyPath := inRequest.GetBodyPath()
+		if bodyPath == "" {
+			continue
+		}
+		if _, exists := data[bodyPath]; exists {
+			s.recordFlag(flag)
+		}
 	}
-	s.flags[flag] = struct{}{}
+}
+
+func (s *stdinSecurity) fileInputFromStdin(flag cli.Flag) bool {
+	_, recorded := s.stdinFlags[flag]
+	return s.enabled && recorded
 }
 
 func (s *stdinSecurity) protectFlagValues(contents *requestflag.RequestContents) {
@@ -51,7 +74,7 @@ func (s *stdinSecurity) protectFlagValues(contents *requestflag.RequestContents)
 		return
 	}
 	body, _ := contents.Body.(map[string]any)
-	for flag := range s.flags {
+	for flag := range s.stdinFlags {
 		inRequest, ok := flag.(requestflag.InRequest)
 		if !ok {
 			continue
@@ -126,24 +149,4 @@ func protectStdinValue(value any) any {
 		return result
 	}
 	return value
-}
-
-func containsUntrustedStdinValue(value any) bool {
-	switch value := value.(type) {
-	case untrustedStdinValue:
-		return true
-	case []any:
-		for _, element := range value {
-			if containsUntrustedStdinValue(element) {
-				return true
-			}
-		}
-	case map[string]any:
-		for _, element := range value {
-			if containsUntrustedStdinValue(element) {
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/pkg/cmd/stdinsecurity_test.go
+++ b/pkg/cmd/stdinsecurity_test.go
@@ -134,6 +134,8 @@ func TestWrapFileInputValuesRejectsUntrustedLocations(t *testing.T) {
 	}{
 		{name: "body", flag: &requestflag.Flag[string]{Name: "file", BodyPath: "file", FileInput: true}, value: untrustedStdinValue("synthetic.txt")},
 		{name: "empty body", flag: &requestflag.Flag[string]{Name: "file", BodyPath: "file", FileInput: true}, value: untrustedStdinValue("")},
+		{name: "null body", flag: &requestflag.Flag[string]{Name: "file", BodyPath: "file", FileInput: true}, value: nil},
+		{name: "number body", flag: &requestflag.Flag[string]{Name: "file", BodyPath: "file", FileInput: true}, value: 123},
 		{name: "body array", flag: &requestflag.Flag[string]{Name: "file", BodyPath: "file", FileInput: true}, value: []any{untrustedStdinValue("synthetic.txt")}},
 		{name: "query", flag: &requestflag.Flag[string]{Name: "file", QueryPath: "file", FileInput: true}, value: untrustedStdinValue("synthetic.txt")},
 		{name: "header", flag: &requestflag.Flag[string]{Name: "file", HeaderPath: "X-File", FileInput: true}, value: untrustedStdinValue("synthetic.txt")},
@@ -149,7 +151,14 @@ func TestWrapFileInputValuesRejectsUntrustedLocations(t *testing.T) {
 				Headers: map[string]any{test.flag.HeaderPath: test.value},
 			}
 
-			err := wrapFileInputValues(&cli.Command{Flags: []cli.Flag{test.flag}}, &contents)
+			command := &cli.Command{Flags: []cli.Flag{test.flag}}
+			security := &stdinSecurity{enabled: true}
+			if test.flag.BodyPath != "" {
+				security.recordBodyFlags(command, contents.Body.(map[string]any))
+			} else {
+				security.recordFlag(test.flag)
+			}
+			err := wrapFileInputValues(command, &contents, security)
 
 			require.ErrorContains(t, err, untrustedStdinEnv)
 			require.ErrorContains(t, err, "provide --file explicitly")
@@ -160,9 +169,13 @@ func TestWrapFileInputValuesRejectsUntrustedLocations(t *testing.T) {
 		t.Parallel()
 
 		flag := &requestflag.Flag[string]{Name: "file", BodyPath: "file", FileInput: true}
+		require.NoError(t, flag.PreParse())
+		require.NoError(t, flag.Set("file", "trusted.txt"))
 		contents := requestflag.RequestContents{Body: map[string]any{"file": "trusted.txt"}}
+		security := &stdinSecurity{enabled: true}
+		security.recordBodyFlags(&cli.Command{Flags: []cli.Flag{flag}}, contents.Body.(map[string]any))
 
-		require.NoError(t, wrapFileInputValues(&cli.Command{Flags: []cli.Flag{flag}}, &contents))
+		require.NoError(t, wrapFileInputValues(&cli.Command{Flags: []cli.Flag{flag}}, &contents, security))
 		require.Equal(t, FilePathValue("trusted.txt"), contents.Body.(map[string]any)["file"])
 	})
 }
@@ -180,8 +193,10 @@ func TestUntrustedStdinFileInputAliasCannotBypassProtection(t *testing.T) {
 	stdin := map[string]any{"upload_alias": "synthetic-private.txt"}
 	applyDataAliases(command, stdin)
 	contents := requestflag.RequestContents{Body: protectStdinValue(stdin)}
+	security := &stdinSecurity{enabled: true}
+	security.recordBodyFlags(command, stdin)
 
-	err := wrapFileInputValues(command, &contents)
+	err := wrapFileInputValues(command, &contents, security)
 
 	require.ErrorContains(t, err, `file input "file"`)
 	require.ErrorContains(t, err, "provide --upload explicitly")
@@ -295,11 +310,23 @@ func TestUntrustedStdinModeEndToEnd(t *testing.T) {
 		require.Equal(t, trustedContent, request.header.Get("Openai-Beta"))
 	})
 
-	t.Run("stdin FileInput fails before request", func(t *testing.T) {
-		request, output, runErr := run(t, fmt.Sprintf("file: %q\npurpose: assistants\n", privateReferencePath), "1", "files", "create")
-		require.Error(t, runErr)
-		require.Contains(t, output, "provide --file explicitly")
-		require.Empty(t, request.request)
+	t.Run("stdin FileInput values fail before request", func(t *testing.T) {
+		for _, test := range []struct {
+			name  string
+			value string
+		}{
+			{name: "path", value: fmt.Sprintf("%q", privateReferencePath)},
+			{name: "empty", value: `""`},
+			{name: "null", value: "null"},
+			{name: "number", value: "123"},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				request, output, runErr := run(t, "file: "+test.value+"\npurpose: assistants\n", "1", "files", "create")
+				require.Error(t, runErr)
+				require.Contains(t, output, "provide --file explicitly")
+				require.Empty(t, request.request)
+			})
+		}
 	})
 
 	t.Run("explicit file flag overrides untrusted stdin", func(t *testing.T) {

--- a/pkg/cmd/stdinsecurity_test.go
+++ b/pkg/cmd/stdinsecurity_test.go
@@ -99,7 +99,7 @@ func TestStdinSecurityProtectsOnlyPipedFlagValues(t *testing.T) {
 	require.Equal(t, untrustedStdinValue("@piped-inner"), nested["untrusted"])
 }
 
-func TestStdinSecurityProtectsPipedInnerArrayFields(t *testing.T) {
+func TestStdinSecurityPreservesExplicitInnerArrayFields(t *testing.T) {
 	t.Parallel()
 
 	outer := &requestflag.Flag[[]map[string]any]{Name: "entries", BodyPath: "entries"}
@@ -120,9 +120,8 @@ func TestStdinSecurityProtectsPipedInnerArrayFields(t *testing.T) {
 
 	require.NoError(t, err)
 	entries := outer.Get().([]map[string]any)
-	require.Len(t, entries, 2)
+	require.Len(t, entries, 1)
 	require.Equal(t, "@trusted-reference", entries[0]["value"])
-	require.Equal(t, untrustedStdinValue("@piped-reference"), entries[1]["value"])
 }
 
 func TestWrapFileInputValuesRejectsUntrustedLocations(t *testing.T) {
@@ -134,6 +133,7 @@ func TestWrapFileInputValuesRejectsUntrustedLocations(t *testing.T) {
 		value any
 	}{
 		{name: "body", flag: &requestflag.Flag[string]{Name: "file", BodyPath: "file", FileInput: true}, value: untrustedStdinValue("synthetic.txt")},
+		{name: "empty body", flag: &requestflag.Flag[string]{Name: "file", BodyPath: "file", FileInput: true}, value: untrustedStdinValue("")},
 		{name: "body array", flag: &requestflag.Flag[string]{Name: "file", BodyPath: "file", FileInput: true}, value: []any{untrustedStdinValue("synthetic.txt")}},
 		{name: "query", flag: &requestflag.Flag[string]{Name: "file", QueryPath: "file", FileInput: true}, value: untrustedStdinValue("synthetic.txt")},
 		{name: "header", flag: &requestflag.Flag[string]{Name: "file", HeaderPath: "X-File", FileInput: true}, value: untrustedStdinValue("synthetic.txt")},

--- a/pkg/cmd/stdinsecurity_test.go
+++ b/pkg/cmd/stdinsecurity_test.go
@@ -1,0 +1,356 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-cli/internal/requestflag"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+func TestNewStdinSecurityRejectsInvalidBoolean(t *testing.T) {
+	t.Setenv(untrustedStdinEnv, "definitely")
+
+	_, err := newStdinSecurity()
+
+	require.ErrorContains(t, err, untrustedStdinEnv)
+	require.ErrorContains(t, err, "expected a boolean")
+}
+
+func TestProtectStdinValuePreservesLiterals(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.ToSlash(filepath.Join(t.TempDir(), "synthetic.txt"))
+	require.NoError(t, os.WriteFile(path, []byte("SYNTHETIC_PRIVATE_CONTENT"), 0o600))
+	pointer := "@" + path
+	input := map[string]any{
+		"plain":   "@" + path,
+		"file":    "@file://" + path,
+		"data":    "@data://" + path,
+		"escaped": "\\@" + path,
+		"pointer": &pointer,
+		"nested": []any{
+			map[string]any{"value": "@" + path},
+			[]string{"@file://" + path},
+			[]map[string]any{{"value": "@data://" + path}},
+		},
+	}
+
+	for _, style := range []FileEmbedStyle{EmbedText, EmbedIOReader} {
+		got, err := embedFiles(protectStdinValue(input), style, nil)
+		require.NoError(t, err)
+		serialized, err := json.Marshal(got)
+		require.NoError(t, err)
+		require.NotContains(t, string(serialized), "SYNTHETIC_PRIVATE_CONTENT")
+		require.Contains(t, string(serialized), "@file://"+path)
+		require.Contains(t, string(serialized), "@data://"+path)
+		require.Equal(t, "\\@"+path, got.(map[string]any)["escaped"])
+	}
+}
+
+func TestStdinSecurityProtectsOnlyPipedFlagValues(t *testing.T) {
+	t.Parallel()
+
+	query := &requestflag.Flag[string]{Name: "query", QueryPath: "query", DataAliases: []string{"query_alias"}}
+	header := &requestflag.Flag[string]{Name: "header", HeaderPath: "X-Test", DataAliases: []string{"header_alias"}}
+	explicit := &requestflag.Flag[string]{Name: "explicit", QueryPath: "explicit"}
+	outer := &requestflag.Flag[map[string]any]{Name: "nested", BodyPath: "nested"}
+	inner := &requestflag.InnerFlag[string]{
+		Name:        "nested.untrusted",
+		InnerField:  "untrusted",
+		DataAliases: []string{"nested_alias"},
+		OuterFlag:   outer,
+	}
+	for _, flag := range []*requestflag.Flag[string]{query, header, explicit} {
+		require.NoError(t, flag.PreParse())
+	}
+	require.NoError(t, outer.PreParse())
+	require.NoError(t, explicit.Set("explicit", "@trusted-query"))
+	require.NoError(t, outer.Set("nested", `{trusted: "@trusted-inner"}`))
+	command := &cli.Command{Flags: []cli.Flag{query, header, explicit, outer, inner}}
+	security := &stdinSecurity{enabled: true}
+
+	require.NoError(t, requestflag.ApplyStdinDataToFlagsWithProvenance(command, map[string]any{
+		"query_alias":  "@piped-query",
+		"header_alias": "@piped-header",
+		"explicit":     "@piped-override",
+		"nested":       map[string]any{"nested_alias": "@piped-inner"},
+	}, security.recordFlag))
+	contents := requestflag.ExtractRequestContents(command)
+	security.protectFlagValues(&contents)
+
+	require.Equal(t, untrustedStdinValue("@piped-query"), contents.Queries["query"])
+	require.Equal(t, untrustedStdinValue("@piped-header"), contents.Headers["X-Test"])
+	require.Equal(t, "@trusted-query", contents.Queries["explicit"])
+	nested := contents.Body.(map[string]any)["nested"].(map[string]any)
+	require.Equal(t, "@trusted-inner", nested["trusted"])
+	require.Equal(t, untrustedStdinValue("@piped-inner"), nested["untrusted"])
+}
+
+func TestStdinSecurityProtectsPipedInnerArrayFields(t *testing.T) {
+	t.Parallel()
+
+	outer := &requestflag.Flag[[]map[string]any]{Name: "entries", BodyPath: "entries"}
+	require.NoError(t, outer.PreParse())
+	require.NoError(t, outer.Set("entries", `{value: "@trusted-reference"}`))
+	inner := &requestflag.InnerFlag[string]{
+		Name:                  "entries.value",
+		InnerField:            "value",
+		OuterFlag:             outer,
+		OuterIsArrayOfObjects: true,
+	}
+	command := &cli.Command{Flags: []cli.Flag{outer, inner}}
+	security := &stdinSecurity{enabled: true}
+
+	err := requestflag.ApplyStdinDataToFlagsWithProvenance(command, map[string]any{
+		"entries": map[string]any{"value": "@piped-reference"},
+	}, security.recordFlag)
+
+	require.NoError(t, err)
+	entries := outer.Get().([]map[string]any)
+	require.Len(t, entries, 2)
+	require.Equal(t, "@trusted-reference", entries[0]["value"])
+	require.Equal(t, untrustedStdinValue("@piped-reference"), entries[1]["value"])
+}
+
+func TestWrapFileInputValuesRejectsUntrustedLocations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		flag  *requestflag.Flag[string]
+		value any
+	}{
+		{name: "body", flag: &requestflag.Flag[string]{Name: "file", BodyPath: "file", FileInput: true}, value: untrustedStdinValue("synthetic.txt")},
+		{name: "body array", flag: &requestflag.Flag[string]{Name: "file", BodyPath: "file", FileInput: true}, value: []any{untrustedStdinValue("synthetic.txt")}},
+		{name: "query", flag: &requestflag.Flag[string]{Name: "file", QueryPath: "file", FileInput: true}, value: untrustedStdinValue("synthetic.txt")},
+		{name: "header", flag: &requestflag.Flag[string]{Name: "file", HeaderPath: "X-File", FileInput: true}, value: untrustedStdinValue("synthetic.txt")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			contents := requestflag.RequestContents{
+				Body:    map[string]any{test.flag.BodyPath: test.value},
+				Queries: map[string]any{test.flag.QueryPath: test.value},
+				Headers: map[string]any{test.flag.HeaderPath: test.value},
+			}
+
+			err := wrapFileInputValues(&cli.Command{Flags: []cli.Flag{test.flag}}, &contents)
+
+			require.ErrorContains(t, err, untrustedStdinEnv)
+			require.ErrorContains(t, err, "provide --file explicitly")
+		})
+	}
+
+	t.Run("explicit CLI path remains trusted", func(t *testing.T) {
+		t.Parallel()
+
+		flag := &requestflag.Flag[string]{Name: "file", BodyPath: "file", FileInput: true}
+		contents := requestflag.RequestContents{Body: map[string]any{"file": "trusted.txt"}}
+
+		require.NoError(t, wrapFileInputValues(&cli.Command{Flags: []cli.Flag{flag}}, &contents))
+		require.Equal(t, FilePathValue("trusted.txt"), contents.Body.(map[string]any)["file"])
+	})
+}
+
+func TestUntrustedStdinFileInputAliasCannotBypassProtection(t *testing.T) {
+	t.Parallel()
+
+	flag := &requestflag.Flag[string]{
+		Name:        "upload",
+		BodyPath:    "file",
+		DataAliases: []string{"upload_alias"},
+		FileInput:   true,
+	}
+	command := &cli.Command{Flags: []cli.Flag{flag}}
+	stdin := map[string]any{"upload_alias": "synthetic-private.txt"}
+	applyDataAliases(command, stdin)
+	contents := requestflag.RequestContents{Body: protectStdinValue(stdin)}
+
+	err := wrapFileInputValues(command, &contents)
+
+	require.ErrorContains(t, err, `file input "file"`)
+	require.ErrorContains(t, err, "provide --upload explicitly")
+}
+
+func TestUntrustedStdinModeEndToEnd(t *testing.T) {
+	privatePath := filepath.Join(t.TempDir(), "synthetic-private.txt")
+	trustedPath := filepath.Join(t.TempDir(), "synthetic-trusted.txt")
+	privateReferencePath := filepath.ToSlash(privatePath)
+	const privateContent = "SYNTHETIC_PRIVATE_CONTENT_DO_NOT_UPLOAD"
+	const trustedContent = "SYNTHETIC_EXPLICIT_UPLOAD_CONTENT"
+	require.NoError(t, os.WriteFile(privatePath, []byte(privateContent), 0o600))
+	require.NoError(t, os.WriteFile(trustedPath, []byte(trustedContent), 0o600))
+
+	binary := filepath.Join(t.TempDir(), "openai")
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", binary, "../../cmd/openai")
+	buildOutput, err := build.CombinedOutput()
+	require.NoError(t, err, "building test CLI: %s", buildOutput)
+
+	type recordedRequest struct {
+		body    []byte
+		header  http.Header
+		query   url.Values
+		request string
+	}
+	requests := make(chan recordedRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, readErr := io.ReadAll(r.Body)
+		if readErr != nil {
+			http.Error(w, readErr.Error(), http.StatusInternalServerError)
+			return
+		}
+		requests <- recordedRequest{body: body, header: r.Header.Clone(), query: r.URL.Query(), request: r.URL.Path}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"synthetic","object":"list","data":[],"has_more":false,"output":[]}`)
+	}))
+	t.Cleanup(server.Close)
+
+	run := func(t *testing.T, stdin, mode string, args ...string) (recordedRequest, string, error) {
+		t.Helper()
+		arguments := append([]string{"--base-url", server.URL, "--api-key", "synthetic-key"}, args...)
+		command := exec.Command(binary, arguments...)
+		command.Stdin = strings.NewReader(stdin)
+		for _, value := range os.Environ() {
+			if !strings.HasPrefix(value, untrustedStdinEnv+"=") {
+				command.Env = append(command.Env, value)
+			}
+		}
+		if mode != "" {
+			command.Env = append(command.Env, untrustedStdinEnv+"="+mode)
+		}
+		output, runErr := command.CombinedOutput()
+		select {
+		case request := <-requests:
+			return request, string(output), runErr
+		default:
+			return recordedRequest{}, string(output), runErr
+		}
+	}
+
+	t.Run("nested JSON and YAML references remain literal", func(t *testing.T) {
+		for _, test := range []struct {
+			name  string
+			stdin string
+		}{
+			{name: "json nested at", stdin: fmt.Sprintf(`{"input":[{"content":{"text":"@%s"}}]}`, privateReferencePath)},
+			{name: "json nested file URI", stdin: fmt.Sprintf(`{"input":[{"content":["@file://%s"]}]}`, privateReferencePath)},
+			{name: "json nested data URI", stdin: fmt.Sprintf(`{"input":{"content":[{"data":"@data://%s"}]}}`, privateReferencePath)},
+			{name: "yaml nested at", stdin: fmt.Sprintf("input:\n  - content:\n      text: '@%s'\n", privateReferencePath)},
+			{name: "yaml nested file URI", stdin: fmt.Sprintf("input:\n  - content:\n      - '@file://%s'\n", privateReferencePath)},
+			{name: "yaml nested data URI", stdin: fmt.Sprintf("input:\n  content:\n    - data: '@data://%s'\n", privateReferencePath)},
+			{name: "yaml anchor alias", stdin: fmt.Sprintf("template: &synthetic '@%s'\ninput:\n  - *synthetic\n", privateReferencePath)},
+			{name: "json root array", stdin: fmt.Sprintf(`[{"nested":"@%s"}]`, privateReferencePath)},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				request, output, runErr := run(t, test.stdin, "1", "responses", "create")
+				require.NoError(t, runErr, "CLI output: %s", output)
+				require.NotContains(t, string(request.body), privateContent)
+				require.Contains(t, string(request.body), privateReferencePath)
+			})
+		}
+	})
+
+	t.Run("stdin query remains literal", func(t *testing.T) {
+		request, output, runErr := run(t, fmt.Sprintf("after: '@file://%s'\n", privateReferencePath), "true", "files", "list")
+		require.NoError(t, runErr, "CLI output: %s", output)
+		require.Equal(t, "@file://"+privateReferencePath, request.query.Get("after"))
+		require.NotContains(t, request.query.Encode(), privateContent)
+	})
+
+	t.Run("stdin header remains literal", func(t *testing.T) {
+		request, output, runErr := run(t, fmt.Sprintf("openai-beta: '@data://%s'\n", privateReferencePath), "1", "beta:responses:input-tokens", "count")
+		require.NoError(t, runErr, "CLI output: %s", output)
+		require.Equal(t, "@data://"+privateReferencePath, request.header.Get("Openai-Beta"))
+	})
+
+	t.Run("explicit query flag overrides untrusted stdin", func(t *testing.T) {
+		stdin := fmt.Sprintf("after: '@file://%s'\n", privateReferencePath)
+		request, output, runErr := run(t, stdin, "1", "files", "list", "--after", "@"+trustedPath)
+		require.NoError(t, runErr, "CLI output: %s", output)
+		require.Equal(t, trustedContent, request.query.Get("after"))
+	})
+
+	t.Run("explicit header flag overrides untrusted stdin", func(t *testing.T) {
+		stdin := fmt.Sprintf("openai-beta: '@data://%s'\n", privateReferencePath)
+		request, output, runErr := run(t, stdin, "1", "beta:responses:input-tokens", "count", "--beta", "@"+trustedPath)
+		require.NoError(t, runErr, "CLI output: %s", output)
+		require.Equal(t, trustedContent, request.header.Get("Openai-Beta"))
+	})
+
+	t.Run("stdin FileInput fails before request", func(t *testing.T) {
+		request, output, runErr := run(t, fmt.Sprintf("file: %q\npurpose: assistants\n", privateReferencePath), "1", "files", "create")
+		require.Error(t, runErr)
+		require.Contains(t, output, "provide --file explicitly")
+		require.Empty(t, request.request)
+	})
+
+	t.Run("explicit file flag overrides untrusted stdin", func(t *testing.T) {
+		request, output, runErr := run(t, fmt.Sprintf("file: %q\npurpose: assistants\n", privateReferencePath), "1", "files", "create", "--file", trustedPath)
+		require.NoError(t, runErr, "CLI output: %s", output)
+		require.Contains(t, string(request.body), trustedContent)
+		require.NotContains(t, string(request.body), privateContent)
+	})
+
+	t.Run("multipart nested stdin references remain literal", func(t *testing.T) {
+		stdin := fmt.Sprintf("purpose: assistants\nexpires_after:\n  anchor: '@file://%s'\n  seconds: 3600\n", privateReferencePath)
+		request, output, runErr := run(t, stdin, "1", "files", "create", "--file", trustedPath)
+		require.NoError(t, runErr, "CLI output: %s", output)
+		require.Contains(t, string(request.body), trustedContent)
+		require.Contains(t, string(request.body), "@file://"+privateReferencePath)
+		require.NotContains(t, string(request.body), privateContent)
+	})
+
+	t.Run("stdin inner array field cannot bypass provenance", func(t *testing.T) {
+		stdin := fmt.Sprintf("context_management:\n  type: '@%s'\n", privateReferencePath)
+		request, output, runErr := run(t, stdin, "1", "responses", "create")
+		require.NoError(t, runErr, "CLI output: %s", output)
+		require.NotContains(t, string(request.body), privateContent)
+		require.Contains(t, string(request.body), "@"+privateReferencePath)
+	})
+
+	t.Run("explicit nested file reference remains trusted", func(t *testing.T) {
+		stdin := fmt.Sprintf(`{"input":"@%s","metadata":{"piped":"@%s"}}`, privateReferencePath, privateReferencePath)
+		request, output, runErr := run(t, stdin, "1", "responses", "create", "--input", "@"+trustedPath)
+		require.NoError(t, runErr, "CLI output: %s", output)
+		require.Contains(t, string(request.body), trustedContent)
+		require.NotContains(t, string(request.body), privateContent)
+		require.Contains(t, string(request.body), privateReferencePath)
+	})
+
+	t.Run("trusted stdin references preserve documented behavior", func(t *testing.T) {
+		request, output, runErr := run(t, fmt.Sprintf(`{"input":{"nested":"@%s"}}`, privateReferencePath), "", "responses", "create")
+		require.NoError(t, runErr, "CLI output: %s", output)
+		require.Contains(t, string(request.body), privateContent)
+	})
+
+	t.Run("trusted stdin FileInput preserves compatibility", func(t *testing.T) {
+		request, output, runErr := run(t, fmt.Sprintf("file: %q\npurpose: assistants\n", trustedPath), "false", "files", "create")
+		require.NoError(t, runErr, "CLI output: %s", output)
+		require.True(t, bytes.Contains(request.body, []byte(trustedContent)))
+	})
+
+	t.Run("invalid security mode fails closed", func(t *testing.T) {
+		request, output, runErr := run(t, fmt.Sprintf(`{"input":"@%s"}`, privateReferencePath), "invalid", "responses", "create")
+		require.Error(t, runErr)
+		require.Contains(t, output, "expected a boolean")
+		require.Empty(t, request.request)
+	})
+}

--- a/pkg/cmd/stdinsecurity_test.go
+++ b/pkg/cmd/stdinsecurity_test.go
@@ -353,6 +353,14 @@ func TestUntrustedStdinModeEndToEnd(t *testing.T) {
 		require.Contains(t, string(request.body), "@"+privateReferencePath)
 	})
 
+	t.Run("explicit empty inner array overrides stdin", func(t *testing.T) {
+		request, output, runErr := run(t, "context_management:\n  type: compaction\n", "1", "responses", "create", "--context-management", "[]")
+		require.NoError(t, runErr, "CLI output: %s", output)
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(request.body, &body))
+		require.Equal(t, []any{}, body["context_management"])
+	})
+
 	t.Run("explicit nested file reference remains trusted", func(t *testing.T) {
 		stdin := fmt.Sprintf(`{"input":"@%s","metadata":{"piped":"@%s"}}`, privateReferencePath, privateReferencePath)
 		request, output, runErr := run(t, stdin, "1", "responses", "create", "--input", "@"+trustedPath)


### PR DESCRIPTION
## Summary

- Add opt-in `OPENAI_UNTRUSTED_STDIN=1` handling for JSON/YAML request documents without changing trusted-input defaults.
- Preserve stdin-versus-CLI provenance across aliases, nested maps and arrays, inner flags, headers, query parameters, and multipart uploads.
- Treat stdin-origin `@`, `@file://`, and `@data://` strings literally and reject stdin-origin `FileInput` paths before sending a request, while preserving explicitly supplied file flags.
- Document the mode and add end-to-end HTTP regressions, provenance unit tests, mixed-origin compatibility coverage, and Windows-safe test helpers.

## Motivation

Pipelines that consume untrusted request documents need a way to prevent stdin-provided values from being reinterpreted as local file references. The new behavior is explicitly enabled for compatibility; existing trusted heredocs and explicit CLI uploads keep their current behavior.

## Verification

```sh
GOFLAGS=-buildvcs=false go test ./internal/requestflag ./pkg/cmd -run 'Stdin|ApplyStdinDataToFlags' -count=1
GOFLAGS=-buildvcs=false go test -race ./internal/requestflag ./pkg/cmd -run 'Stdin|ApplyStdinDataToFlags' -count=1
GOFLAGS=-buildvcs=false go test ./... -run '^$'
GOFLAGS=-buildvcs=false ./scripts/lint
GOFLAGS=-buildvcs=false go vet ./...
```

The full integration suite, Windows amd64 test compilation, module verification, vulnerability-check harness, and GoReleaser installer test also passed during final private review. No Castiron-generated source, generator-owned template, workflow, or custom-code budget was changed.
