### PR TITLE
chore(api): update generation metadata only

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,8 +1,8 @@
 schema_version: 1
-generation_id: 06629b84-3bdf-4a49-ac7d-ca3ea4de3019
+generation_id: 2cb1a6d4-a3c6-40f7-8a76-d23887849b3c
 openapi_spec_hash: b2c62b342b04685226037c980f2b5a7a
 openapi_transformed_spec_hash: ba44bf31326f01a1d886b7510dd9da8a
-config_hash: 1e11a5becf7bc1c2e9e07b8654872dc4
-codegen_sha: a8786e530028799142c368fe67677f0f85752cae
+config_hash: 4fbbbcf377bcc17646cccb9fcfbac14a
+codegen_sha: 0021550598b89e4beb7c84cbeeddce84071a2bdd
 codegen_hash: c70f5adea80c1c0a55a1baa900e0d1b426fe7eab7b3f784e1f8fa618d55d636f
-public_codegen_sha: ad20e5c41afb4698319bf996a145056997dad89d
+public_codegen_sha: 621a4e6e6f5433a7c71a066556bc403700584db4


### PR DESCRIPTION
## Summary

Keep the CLI’s generation metadata aligned with the coordinated SDK update.

The CLI still does not expose Realtime call creation. This PR changes only generation metadata; commands, runtime behavior, and the public API reference are unchanged.
