### PR TITLE
fix(jsonview): preserve literal object keys in pretty output and explorer

### DIFF
--- a/internal/jsonview/explorer.go
+++ b/internal/jsonview/explorer.go
@@ -183,12 +183,13 @@ func (tv *TableView) appendItem(result gjson.Result, raw bool) {
 	newRow := table.Row{formatValue(result, raw)}
 	if len(tv.columns) > 1 && result.IsObject() {
 		newRow = make(table.Row, len(tv.columns))
+		values := result.Map()
 		for i, col := range tv.columns {
 			key := col.Title
 			if i < len(tv.columnKeys) {
 				key = tv.columnKeys[i]
 			}
-			newRow[i] = formatValue(result.Get(key), raw)
+			newRow[i] = formatValue(values[key], raw)
 		}
 	}
 	tv.table.SetRows(append(tv.table.Rows(), newRow))
@@ -639,8 +640,9 @@ func newArrayOfObjectsTableView(path string, data gjson.Result, array []gjson.Re
 
 	for _, item := range array {
 		row := make(table.Row, len(columns))
+		values := item.Map()
 		for i, key := range columnKeys {
-			row[i] = formatValue(item.Get(key), raw)
+			row[i] = formatValue(values[key], raw)
 		}
 		rows = append(rows, row)
 		rowData = append(rowData, item)
@@ -663,9 +665,10 @@ func newObjectTableView(path string, data gjson.Result, raw bool) *TableView {
 	keys := data.Get("@keys").Array()
 	rows := make([]table.Row, 0, len(keys))
 	rowData := make([]gjson.Result, 0, len(keys))
+	values := data.Map()
 
 	for _, key := range keys {
-		value := data.Get(key.Str)
+		value := values[key.Str]
 		title := SanitizeTerminalString(key.Str)
 		rows = append(rows, table.Row{title, formatValue(value, raw)})
 		rowData = append(rowData, value)
@@ -733,9 +736,10 @@ func formatValue(value gjson.Result, raw bool) string {
 func formatObject(value gjson.Result) string {
 	keys := value.Get("@keys").Array()
 	keyStrs := make([]string, len(keys))
+	values := value.Map()
 
 	for i, key := range keys {
-		val := value.Get(key.Str)
+		val := values[key.Str]
 		keyStrs[i] = formatObjectKey(SanitizeTerminalString(key.Str), val)
 	}
 

--- a/internal/jsonview/literal_keys_test.go
+++ b/internal/jsonview/literal_keys_test.go
@@ -1,0 +1,63 @@
+package jsonview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestStaticDisplayUsesLiteralObjectKeys(t *testing.T) {
+	t.Parallel()
+
+	result := gjson.Parse(`{"a.b":"literal-value","a":{"b":"nested-value"}}`)
+	out := formatJSON(result, 80)
+
+	require.Contains(t, out, "literal-value")
+	require.Contains(t, out, "nested-value")
+}
+
+func TestExploreTableUsesLiteralObjectKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ObjectView", func(t *testing.T) {
+		t.Parallel()
+
+		result := gjson.Parse(`{"a.b":"literal-value","a":{"b":"nested-value"}}`)
+		view, err := newTableView("", result, false)
+		require.NoError(t, err)
+
+		rows := view.table.Rows()
+		require.Len(t, rows, 2)
+		require.Equal(t, "a.b", rows[0][0])
+		require.Equal(t, "literal-value", rows[0][1])
+		require.Equal(t, "a", rows[1][0])
+	})
+
+	t.Run("ArrayOfObjectsView", func(t *testing.T) {
+		t.Parallel()
+
+		result := gjson.Parse(`[{"a.b":"literal-value","a":{"b":"nested-value"}}]`)
+		view, err := newTableView("", result, false)
+		require.NoError(t, err)
+
+		columns := view.table.Columns()
+		rows := view.table.Rows()
+
+		require.Len(t, columns, 2)
+		require.Equal(t, "a.b", columns[0].Title)
+		require.Equal(t, "a", columns[1].Title)
+
+		require.Len(t, rows, 1)
+		require.Equal(t, "literal-value", rows[0][0])
+	})
+}
+
+func TestExploreFormatObjectUsesLiteralObjectKeys(t *testing.T) {
+	t.Parallel()
+
+	result := gjson.Parse(`{"a.b":"literal-value","a":{"b":"nested-value"}}`)
+	got := formatValue(result, false)
+
+	require.Contains(t, got, `a.b:"literal-value"`)
+}

--- a/internal/jsonview/staticdisplay.go
+++ b/internal/jsonview/staticdisplay.go
@@ -100,10 +100,11 @@ func formatJSONObject(result gjson.Result, indent, width int) string {
 	if len(keys) == 0 {
 		return nullValueStyle.Render("(empty)")
 	}
+	values := result.Map()
 
 	var items []string
 	for _, key := range keys {
-		value := result.Get(key.Str)
+		value := values[key.Str]
 		keyStr := getIndent(indent) + keyStyle.Render(SanitizeTerminalString(key.Str)+":")
 		// If item will be a one-liner, put it inline after the key, otherwise
 		// it starts with a newline and goes below the key.


### PR DESCRIPTION
## Summary

Preserve literal object keys across pretty formatting and the interactive JSON explorer instead of resolving member names containing dots or metacharacters as GJSON query paths.

Fixes #81.

## Problem & Root Cause

The JSON renderer and explorer enumerate literal member names with `@keys` / `gjson.Result.Get("@keys")`, but subsequently fetched each value through `result.Get(key.Str)`, `data.Get(key.Str)`, or `item.Get(key)`.

Because GJSON interprets string arguments to `.Get()` as path expressions (such as evaluating `"a.b"` as a traversal into nested object `a -> b`), keys with dots or other GJSON path syntax either:
1. Display a nested child value under a top-level key's label, or
2. Fail to find any value and display empty/null even when the literal key exists.

## Fix

Materialize the object map once with `result.Map()` and look up values by exact literal key:
- `internal/jsonview/staticdisplay.go`: `formatJSONObject`
- `internal/jsonview/explorer.go`: `newObjectTableView`, `newArrayOfObjectsTableView`, `TableView.loadMoreData`, and `formatObject`

## Regression Coverage

Added comprehensive regression tests in `internal/jsonview/literal_keys_test.go`:
- `TestStaticDisplayUsesLiteralObjectKeys`: confirms static pretty formatting preserves top-level dotted keys and nested paths concurrently.
- `TestExploreTableUsesLiteralObjectKeys`: confirms object table view and array-of-objects table view display the literal key's value.
- `TestExploreFormatObjectUsesLiteralObjectKeys`: confirms object previews format literal keys correctly.

## Validation Commands & Results

- `go test -v ./internal/jsonview/...` (PASS)
- `go test ./pkg/cmd -run TestFormatJSON` (PASS)
- `go vet ./internal/... ./pkg/...` (PASS, clean)
- `go mod verify` (PASS, all modules verified)
- `git diff --check` (PASS, clean)
