### PR TITLE
fix(output): preserve upstream errors when streaming

### DIFF
--- a/pkg/cmd/cmdutil.go
+++ b/pkg/cmd/cmdutil.go
@@ -171,12 +171,14 @@ func streamToPagerWithPipe(label string, generateOutput func(w *os.File) error) 
 		os.Setenv("FORCE_COLOR", "1")
 	}
 
-	if err := generateOutput(w); err != nil && !isOutputBrokenPipe(err) {
-		return err
-	}
-
+	outputErr := generateOutput(w)
+	// Deliver EOF and reap the pager even when output generation failed.
 	w.Close()
-	return cmd.Wait()
+	waitErr := cmd.Wait()
+	if outputErr != nil && !isOutputBrokenPipe(outputErr) {
+		return outputErr
+	}
+	return waitErr
 }
 
 func streamToStdout(generateOutput func(w *os.File) error) error {

--- a/pkg/cmd/cmdutil.go
+++ b/pkg/cmd/cmdutil.go
@@ -171,7 +171,7 @@ func streamToPagerWithPipe(label string, generateOutput func(w *os.File) error) 
 		os.Setenv("FORCE_COLOR", "1")
 	}
 
-	if err := generateOutput(w); err != nil && !strings.Contains(err.Error(), "broken pipe") {
+	if err := generateOutput(w); err != nil && !isOutputBrokenPipe(err) {
 		return err
 	}
 
@@ -182,10 +182,21 @@ func streamToPagerWithPipe(label string, generateOutput func(w *os.File) error) 
 func streamToStdout(generateOutput func(w *os.File) error) error {
 	signal.Ignore(syscall.SIGPIPE)
 	err := generateOutput(os.Stdout)
-	if err != nil && strings.Contains(err.Error(), "broken pipe") {
+	if isOutputBrokenPipe(err) {
 		return nil
 	}
 	return err
+}
+
+// outputWriteError identifies failures from the output sink, rather than from
+// the iterator, transport, or formatter producing the output.
+type outputWriteError struct{ error }
+
+func (e *outputWriteError) Unwrap() error { return e.error }
+
+func isOutputBrokenPipe(err error) bool {
+	var outputErr *outputWriteError
+	return errors.As(err, &outputErr) && strings.Contains(outputErr.Error(), "broken pipe")
 }
 
 // writeBinaryResponse writes a binary response to stdout or a file.
@@ -407,6 +418,9 @@ func formatJSONForOutput(res gjson.Result, opts ShowJSONOpts, destination io.Wri
 			return nil, err
 		}
 		_, err := opts.Stdout.Write([]byte(yaml.String()))
+		if err != nil {
+			return nil, &outputWriteError{err}
+		}
 		return nil, err
 	default:
 		return nil, fmt.Errorf("Invalid format: %s, valid formats are: %s", opts.Format, strings.Join(OutputFormats, ", "))
@@ -545,7 +559,7 @@ func ShowJSONIterator[T any](iter jsonview.Iterator[T], itemsToDisplay int64, op
 	return streamOutput(opts.Title, func(pager *os.File) error {
 		_, err := pager.Write(output)
 		if err != nil {
-			return err
+			return &outputWriteError{err}
 		}
 
 		pagerOpts := opts
@@ -571,7 +585,7 @@ func ShowJSONIterator[T any](iter jsonview.Iterator[T], itemsToDisplay int64, op
 				return err
 			}
 			if _, err := pager.Write(formatted); err != nil {
-				return err
+				return &outputWriteError{err}
 			}
 			itemsToDisplay -= 1
 		}

--- a/pkg/cmd/cmdutil_output_errors_test.go
+++ b/pkg/cmd/cmdutil_output_errors_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type failingOutputIterator struct {
+	sliceIterator[string]
+	err error
+}
+
+func (it *failingOutputIterator) Err() error { return it.err }
+
+func TestShowJSONIteratorPreservesUpstreamErrors(t *testing.T) {
+	for _, upstream := range []error{
+		errors.New("upstream disconnected"),
+		errors.New("upstream broken pipe"),
+		fmt.Errorf("upstream transport: %w", syscall.EPIPE),
+	} {
+		t.Run(upstream.Error(), func(t *testing.T) {
+			output, err := os.CreateTemp(t.TempDir(), "output")
+			require.NoError(t, err)
+			defer output.Close()
+			previous := os.Stdout
+			os.Stdout = output
+			t.Cleanup(func() { os.Stdout = previous })
+			iter := &failingOutputIterator{
+				sliceIterator: sliceIterator[string]{items: []string{strings.Repeat("x", 4000), "last item"}},
+				err:           upstream,
+			}
+			err = ShowJSONIterator[string](iter, -1, ShowJSONOpts{Format: "raw", Stdout: output})
+			require.ErrorIs(t, err, upstream)
+			contents, err := os.ReadFile(output.Name())
+			require.NoError(t, err)
+			require.Contains(t, string(contents), "last item")
+		})
+	}
+}
+
+type failingOutputMarshaler struct{ err error }
+
+func (value failingOutputMarshaler) MarshalJSON() ([]byte, error) { return nil, value.err }
+
+func TestShowJSONIteratorPreservesFormatterError(t *testing.T) {
+	output, err := os.CreateTemp(t.TempDir(), "output")
+	require.NoError(t, err)
+	defer output.Close()
+	previous := os.Stdout
+	os.Stdout = output
+	t.Cleanup(func() { os.Stdout = previous })
+	upstream := errors.New("marshal broken pipe")
+	iter := &sliceIterator[any]{items: []any{strings.Repeat("x", 4000), failingOutputMarshaler{upstream}}}
+	require.ErrorIs(t, ShowJSONIterator[any](iter, -1, ShowJSONOpts{Format: "raw", Stdout: output}), upstream)
+}

--- a/pkg/cmd/cmdutil_output_errors_unix_test.go
+++ b/pkg/cmd/cmdutil_output_errors_unix_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -82,4 +83,64 @@ func TestShowJSONIteratorClosedOutput(t *testing.T) {
 	t.Cleanup(func() { os.Stdout = previous })
 	iter := &sliceIterator[string]{items: []string{strings.Repeat("x", 4000)}}
 	require.NoError(t, ShowJSONIterator[string](iter, -1, ShowJSONOpts{Format: "raw", Stdout: w}))
+}
+
+func TestStreamOutputReapsPagerOnGenerationError(t *testing.T) {
+	paths := map[string]func(string, func(*os.File) error) error{
+		"pipe":   streamToPagerWithPipe,
+		"socket": streamOutputOSSpecific,
+	}
+	for name, stream := range paths {
+		for _, exitCode := range []string{"0", "7"} {
+			for _, upstream := range []error{nil, errors.New("upstream broken pipe"), fmt.Errorf("transport: %w", syscall.EPIPE), errors.New("formatting failed")} {
+				t.Run(fmt.Sprintf("%s/exit%s/%v", name, exitCode, upstream), func(t *testing.T) {
+					dir := t.TempDir()
+					pidPath, outputPath := filepath.Join(dir, "pid"), filepath.Join(dir, "output")
+					pager := filepath.Join(dir, "pager")
+					require.NoError(t, os.WriteFile(pager, []byte("#!/bin/sh\nprintf '%s' \"$$\" > \"$C02_PAGER_PID\"\ncat > \"$C02_PAGER_OUTPUT\"\nexit \"$C02_PAGER_EXIT\"\n"), 0700))
+					t.Setenv("PAGER", pager)
+					t.Setenv("C02_PAGER_PID", pidPath)
+					t.Setenv("C02_PAGER_OUTPUT", outputPath)
+					t.Setenv("C02_PAGER_EXIT", exitCode)
+					var writer *os.File
+					pid := 0
+					err := stream("test", func(w *os.File) error {
+						writer = w
+						require.Eventually(t, func() bool {
+							data, err := os.ReadFile(pidPath)
+							if err != nil {
+								return false
+							}
+							pid, err = strconv.Atoi(string(data))
+							return err == nil && pid > 0
+						}, 5*time.Second, time.Millisecond)
+						// Reap even when testing an implementation that returns too early.
+						t.Cleanup(func() { var status syscall.WaitStatus; _, _ = syscall.Wait4(pid, &status, 0, nil) })
+						if name == "socket" {
+							require.Equal(t, "parent-socket", w.Name())
+						}
+						_, err := w.WriteString("partial output\n")
+						require.NoError(t, err)
+						return upstream
+					})
+					if upstream != nil {
+						require.Same(t, upstream, err)
+					} else if exitCode == "0" {
+						require.NoError(t, err)
+					} else {
+						require.Error(t, err)
+					}
+					require.NotNil(t, writer)
+					_, statErr := writer.Stat()
+					require.ErrorIs(t, statErr, os.ErrClosed)
+					var status syscall.WaitStatus
+					_, waitErr := syscall.Wait4(pid, &status, syscall.WNOHANG, nil)
+					require.ErrorIs(t, waitErr, syscall.ECHILD, "pager must already be reaped before return")
+					output, err := os.ReadFile(outputPath)
+					require.NoError(t, err)
+					require.Equal(t, "partial output\n", string(output))
+				})
+			}
+		}
+	}
 }

--- a/pkg/cmd/cmdutil_output_errors_unix_test.go
+++ b/pkg/cmd/cmdutil_output_errors_unix_test.go
@@ -1,0 +1,85 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamOutputErrorOrigins(t *testing.T) {
+	paths := map[string]func(func(*os.File) error) error{
+		"stdout":       streamToStdout,
+		"pipe pager":   func(generate func(*os.File) error) error { return streamToPagerWithPipe("test", generate) },
+		"socket pager": func(generate func(*os.File) error) error { return streamOutputOSSpecific("test", generate) },
+	}
+	for name, stream := range paths {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("PAGER", "cat")
+			output, err := os.CreateTemp(t.TempDir(), "output")
+			require.NoError(t, err)
+			defer output.Close()
+			previous := os.Stdout
+			os.Stdout = output
+			t.Cleanup(func() { os.Stdout = previous })
+			for _, upstream := range []error{errors.New("ordinary failure"), errors.New("upstream broken pipe"), fmt.Errorf("transport: %w", syscall.EPIPE)} {
+				require.ErrorIs(t, stream(func(w *os.File) error {
+					_, err := w.WriteString("partial output\n")
+					require.NoError(t, err)
+					return upstream
+				}), upstream)
+			}
+			ready := filepath.Join(t.TempDir(), "ready")
+			pager := filepath.Join(t.TempDir(), "pager")
+			require.NoError(t, os.WriteFile(pager, []byte("#!/bin/sh\nexec 0<&-\nprintf ready > \"$C02_PAGER_READY\"\n"), 0700))
+			t.Setenv("PAGER", pager)
+			t.Setenv("C02_PAGER_READY", ready)
+			if name == "stdout" {
+				r, w, err := os.Pipe()
+				require.NoError(t, err)
+				require.NoError(t, r.Close())
+				defer w.Close()
+				os.Stdout = w
+			}
+			var writeErr error
+			err = stream(func(w *os.File) error {
+				if name != "stdout" {
+					// Wait for the reader to close before writing: closing a socket
+					// with unread data can instead produce ECONNRESET.
+					require.Eventually(t, func() bool {
+						_, err := os.Stat(ready)
+						return err == nil
+					}, 5*time.Second, time.Millisecond)
+				}
+				for i := 0; i < 100; i++ {
+					if _, writeErr = w.WriteString(strings.Repeat("x", 65536)); writeErr != nil {
+						return &outputWriteError{writeErr}
+					}
+				}
+				return nil
+			})
+			require.ErrorIs(t, writeErr, syscall.EPIPE)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestShowJSONIteratorClosedOutput(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	defer w.Close()
+	previous := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = previous })
+	iter := &sliceIterator[string]{items: []string{strings.Repeat("x", 4000)}}
+	require.NoError(t, ShowJSONIterator[string](iter, -1, ShowJSONOpts{Format: "raw", Stdout: w}))
+}

--- a/pkg/cmd/cmdutil_unix.go
+++ b/pkg/cmd/cmdutil_unix.go
@@ -38,11 +38,7 @@ func streamOutputOSSpecific(label string, generateOutput func(w *os.File) error)
 		os.Setenv("FORCE_COLOR", "1")
 	}
 
-	// Only output-side broken pipes indicate that the pager stopped reading.
-	if err := generateOutput(pagerInput); err != nil &&
-		!isOutputBrokenPipe(err) {
-		return err
-	}
+	outputErr := generateOutput(pagerInput)
 
 	// Close the file NOW before we wait for the child process to terminate.
 	// This way, the child will receive the end-of-file signal and know that
@@ -54,6 +50,10 @@ func streamOutputOSSpecific(label string, generateOutput func(w *os.File) error)
 	// Wait for child process to exit
 	var wstatus syscall.WaitStatus
 	_, err = syscall.Wait4(pid, &wstatus, 0, nil)
+	// Preserve generation errors, but only after closing and reaping the pager.
+	if outputErr != nil && !isOutputBrokenPipe(outputErr) {
+		return outputErr
+	}
 	if wstatus.ExitStatus() != 0 {
 		return fmt.Errorf("Pager exited with non-zero exit status: %d", wstatus.ExitStatus())
 	}

--- a/pkg/cmd/cmdutil_unix.go
+++ b/pkg/cmd/cmdutil_unix.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -39,10 +38,9 @@ func streamOutputOSSpecific(label string, generateOutput func(w *os.File) error)
 		os.Setenv("FORCE_COLOR", "1")
 	}
 
-	// If the pager exits before reading all input, then generateOutput() will
-	// produce a broken pipe error, which is fine and we don't want to propagate it.
+	// Only output-side broken pipes indicate that the pager stopped reading.
 	if err := generateOutput(pagerInput); err != nil &&
-		!strings.Contains(err.Error(), "broken pipe") {
+		!isOutputBrokenPipe(err) {
 		return err
 	}
 


### PR DESCRIPTION
## Problem and behavior

Once paginated output started streaming, an iterator or API error containing `broken pipe` was silently treated as successful output completion. The same suppression applied to upstream transport errors wrapping a pipe error.

Mark errors at the actual output-write sites and require that origin before treating a broken pipe as graceful completion. Upstream iterator, transport, and formatting errors now propagate. Both pager paths close their input and reap the child before returning a generation error, preserving that error even if the pager also fails. Partial output, streaming, pager selection, formats, platform dispatch, and pagination limits are preserved.

## Validation

- Regression failed on the original code for an upstream message and wrapped `EPIPE`, then passed with the fix; ordinary errors and partial output are covered.
- Focused iterator/output tests passed, including race testing, actual closed stdout pipe, and early closure in both pipe and Unix socket pager paths. Cleanup regressions verify closed input, a reaped child, partial output, and original-error precedence for both backends with successful and unsuccessful pager exits; these regressions failed before the cleanup repair.
- Local synthetic two-page HTTP/CLI check: both `upstream disconnected` and `upstream broken pipe` made exactly two requests and exited 1 with partial output preserved. No live API calls.
- `go test ./internal/...`, `go test ./... -run '^$'`, `go mod verify`, and `./scripts/lint` passed. The lint script performs a build.
- Windows amd64 `pkg/cmd` tests cross-compiled; Windows execution and the complete mock integration suite were not run.
- Custom-code report and budget passed: 495/1000 lines, unchanged generated ownership.
- Two consecutive independent review rounds completed without in-scope blockers on the unchanged diff.
