### PR TITLE
fix(jsonview): retain lazy-loaded items across JSON toggles

### DIFF
--- a/internal/jsonview/explorer.go
+++ b/internal/jsonview/explorer.go
@@ -138,65 +138,56 @@ func (tv *TableView) Update(msg tea.Msg, raw bool) tea.Cmd {
 		// Load more when we're at the last row
 		if cursor == totalRows-1 {
 			tv.isLoading = true
-			return tv.loadMoreData(raw)
+			return tv.loadMoreData()
 		}
 	}
 
 	return cmd
 }
 
-func (tv *TableView) loadMoreData(raw bool) tea.Cmd {
+// tableItemMsg transfers iterator work back to the UI loop. Commands must not
+// mutate a view while key and resize messages are being processed.
+type tableItemMsg struct {
+	view   *TableView
+	result gjson.Result
+	err    error
+}
+
+func (tv *TableView) loadMoreData() tea.Cmd {
+	iterator := tv.iterator
 	return func() tea.Msg {
-		if tv.iterator == nil {
-			return nil
+		msg := tableItemMsg{view: tv}
+		if iterator == nil {
+			return msg
 		}
-
-		if !tv.iterator.Next() {
-			tv.isLoading = false
-			return tv.iterator.Err()
+		if !iterator.Next() {
+			msg.err = iterator.Err()
+			return msg
 		}
-
-		obj := tv.iterator.Current()
-		var result gjson.Result
-		if jsonBytes, err := json.Marshal(obj); err != nil {
-			return err
-		} else {
-			result = gjson.ParseBytes(jsonBytes)
+		jsonBytes, err := json.Marshal(iterator.Current())
+		msg.err = err
+		if err == nil {
+			msg.result = gjson.ParseBytes(jsonBytes)
 		}
-
-		if !result.Exists() {
-			tv.isLoading = false
-			return nil
-		}
-
-		// Add the new item to our data
-		tv.rowData = append(tv.rowData, result)
-
-		// Add new row to the table
-		newRow := table.Row{formatValue(result, raw)}
-
-		// For array of objects, we need to format according to columns
-		if len(tv.columns) > 1 && result.IsObject() {
-			newRow = make(table.Row, len(tv.columns))
-			for i, col := range tv.columns {
-				key := col.Title
-				if i < len(tv.columnKeys) {
-					key = tv.columnKeys[i]
-				}
-				newRow[i] = formatValue(result.Get(key), raw)
-			}
-		}
-
-		rows := tv.table.Rows()
-		rows = append(rows, newRow)
-		tv.table.SetRows(rows)
-
-		// Resize columns to accommodate the new data
-		tv.Resize(tv.width, tv.height)
-
-		tv.isLoading = false
-		return nil
+		return msg
 	}
+}
+
+func (tv *TableView) appendItem(result gjson.Result, raw bool) {
+	tv.rowData = append(tv.rowData, result)
+	newRow := table.Row{formatValue(result, raw)}
+	if len(tv.columns) > 1 && result.IsObject() {
+		newRow = make(table.Row, len(tv.columns))
+		for i, col := range tv.columns {
+			key := col.Title
+			if i < len(tv.columnKeys) {
+				key = tv.columnKeys[i]
+			}
+			newRow[i] = formatValue(result.Get(key), raw)
+		}
+	}
+	tv.table.SetRows(append(tv.table.Rows(), newRow))
+	tv.Resize(tv.width, tv.height)
 }
 
 func (tv *TableView) Resize(width, height int) {
@@ -398,6 +389,18 @@ func (v *JSONViewer) resize(width, height int) {
 
 func (v *JSONViewer) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case tableItemMsg:
+		// A load can finish while a nested view is active.
+		for _, view := range v.stack {
+			if view == msg.view {
+				msg.view.isLoading = false
+				if msg.err == nil && msg.result.Exists() {
+					msg.view.appendItem(msg.result, v.rawMode)
+				}
+				break
+			}
+		}
+		return v, nil
 	case tea.WindowSizeMsg:
 		v.resize(msg.Width-borderPadding, msg.Height)
 		return v, nil
@@ -500,14 +503,21 @@ func (v *JSONViewer) toggleRaw() (tea.Model, tea.Cmd) {
 	v.rawMode = !v.rawMode
 
 	for i, view := range v.stack {
+		if tv, ok := view.(*TableView); ok && tv.data.IsArray() {
+			// rowData includes completed lazy loads. Rebuild only the presentation,
+			// retaining the view identity and any pending iterator command.
+			var rendered *TableView
+			if isArrayOfObjects(tv.rowData) {
+				rendered = newArrayOfObjectsTableView(tv.path, tv.data, tv.rowData, v.rawMode)
+			} else {
+				rendered = newArrayTableView(tv.path, tv.data, tv.rowData, v.rawMode)
+			}
+			tv.table, tv.columns, tv.columnKeys = rendered.table, rendered.columns, rendered.columnKeys
+			continue
+		}
 		viewWithRaw, err := newView(view.GetPath(), view.GetData(), v.rawMode)
 		if err != nil {
 			return v, tea.Printf("Error: %s", err)
-		}
-		if newTV, ok := viewWithRaw.(*TableView); ok {
-			if tv, ok := view.(*TableView); ok && tv.iterator != nil {
-				newTV.iterator = tv.iterator
-			}
 		}
 		v.stack[i] = viewWithRaw
 	}

--- a/internal/jsonview/explorer_stream_test.go
+++ b/internal/jsonview/explorer_stream_test.go
@@ -1,0 +1,144 @@
+package jsonview
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/help"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+type explorerIterator struct {
+	items []any
+	index int
+}
+
+func (it *explorerIterator) Next() bool   { it.index++; return it.index <= len(it.items) }
+func (it *explorerIterator) Current() any { return it.items[it.index-1] }
+func (it *explorerIterator) Err() error   { return nil }
+
+func explorerKey(v *JSONViewer, key string) tea.Cmd {
+	_, cmd := v.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)})
+	return cmd
+}
+
+func TestExplorerToggleRetainsLoadedItems(t *testing.T) {
+	view, err := newTableView("", gjson.Parse(`[{"id":"first"}]`), false)
+	require.NoError(t, err)
+	it := &explorerIterator{items: []any{json.RawMessage(`{"id":"second"}`), json.RawMessage(`{"id":"third"}`)}}
+	view.iterator = it
+	v := &JSONViewer{stack: []JSONView{view}, root: "test", help: help.New()}
+	v.resize(80, 24)
+	cmd := explorerKey(v, "j")
+	require.NotNil(t, cmd)
+	v.Update(cmd())
+	require.Len(t, v.current().(*TableView).rowData, 2)
+	for i := 0; i < 4; i++ {
+		explorerKey(v, "r")
+		tv := v.current().(*TableView)
+		require.Len(t, tv.rowData, 2, "toggle discarded loaded data")
+		require.Equal(t, "first", tv.rowData[0].Get("id").Str)
+		require.Equal(t, "second", tv.rowData[1].Get("id").Str)
+	}
+	cmd = explorerKey(v, "j")
+	require.NotNil(t, cmd)
+	v.Update(cmd())
+	explorerKey(v, "r")
+	tv := v.current().(*TableView)
+	require.Len(t, tv.rowData, 3)
+	require.Equal(t, "third", tv.rowData[2].Get("id").Str)
+	require.Equal(t, 2, it.index)
+	tv.table.SetCursor(2)
+	cmd = explorerKey(v, "j")
+	require.NotNil(t, cmd)
+	v.Update(cmd())
+	explorerKey(v, "r")
+	require.Len(t, v.current().(*TableView).rowData, 3)
+	require.Equal(t, 3, it.index)
+}
+
+type blockedExplorerIterator struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (it *blockedExplorerIterator) Next() bool {
+	close(it.started)
+	<-it.release
+	return true
+}
+func (it *blockedExplorerIterator) Current() any {
+	return json.RawMessage(`{"id":"second","value":"\u001b]52;c;sample\u0007"}`)
+}
+func (it *blockedExplorerIterator) Err() error { return nil }
+
+func TestExplorerToggleDuringLoad(t *testing.T) {
+	for _, nested := range []bool{false, true} {
+		t.Run(fmt.Sprintf("nested=%v", nested), func(t *testing.T) {
+			view, err := newTableView("", gjson.Parse(`[{"id":"first","value":"initial"}]`), false)
+			require.NoError(t, err)
+			it := &blockedExplorerIterator{started: make(chan struct{}), release: make(chan struct{})}
+			view.iterator = it
+			v := &JSONViewer{stack: []JSONView{view}, root: "test", help: help.New()}
+			v.resize(80, 24)
+			cmd := explorerKey(v, "j")
+			require.NotNil(t, cmd)
+			done := make(chan tea.Msg, 1)
+			go func() { done <- cmd() }()
+			<-it.started
+			// Ensure the blocked command is released even if an assertion fails.
+			defer close(it.release)
+			for i := 0; i < 3; i++ {
+				explorerKey(v, "r")
+				require.Nil(t, explorerKey(v, "j"), "must not schedule a second iterator read")
+				v.Update(tea.WindowSizeMsg{Width: 90, Height: 30})
+				_ = v.View()
+			}
+			if nested {
+				explorerKey(v, "l")
+				require.Len(t, v.stack, 2)
+			}
+			// Unblock without closing twice in the deferred cleanup.
+			it.release <- struct{}{}
+			msg := <-done
+			v.Update(msg)
+			if nested {
+				require.Len(t, v.stack, 2)
+				explorerKey(v, "h")
+			}
+			tv := v.current().(*TableView)
+			require.Len(t, tv.rowData, 2)
+			require.False(t, tv.isLoading)
+			require.Equal(t, `"second"`, tv.table.Rows()[1][0])
+			requireNoRawTerminalControls(t, tv.table.Rows()[1][1])
+			explorerKey(v, "r")
+			require.Equal(t, "second", tv.table.Rows()[1][0])
+			tv.table.SetCursor(1)
+			explorerKey(v, "l")
+			require.Equal(t, "[1]", v.current().GetPath())
+			require.Equal(t, "second", v.current().GetData().Get("id").Str)
+			explorerKey(v, "r")
+			explorerKey(v, "h")
+			require.Len(t, v.current().(*TableView).rowData, 2)
+		})
+	}
+}
+
+func TestExplorerToggleNonstreaming(t *testing.T) {
+	for _, input := range []string{`[1,"two",null]`, `[{"id":"one"},{"id":"two"}]`, `{"id":"one","value":[1,2]}`, `"line one\nline two"`} {
+		t.Run(input, func(t *testing.T) {
+			view, err := newView("", gjson.Parse(input), false)
+			require.NoError(t, err)
+			v := &JSONViewer{stack: []JSONView{view}, root: "test", help: help.New()}
+			v.resize(80, 24)
+			before := v.View()
+			explorerKey(v, "r")
+			require.Equal(t, input, v.current().GetData().Raw)
+			explorerKey(v, "r")
+			require.Equal(t, before, v.View())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

After the JSON explorer loads additional items, pressing `r` rebuilds the view from its original preload and discards the loaded rows while keeping the advanced iterator. Keep array views and render toggles from all accumulated rows so repeated toggles and continued loading retain item order without skips or duplicates.

Iterator commands now return results to the UI update loop. This keeps an in-flight load attached to its original view across toggles and nested navigation, and formats its result using the current display mode. Existing nonstreaming rendering and terminal escaping remain unchanged; no dependencies or generated sources change.

## Validation

- The new key-message retention regression fails on unchanged main and passes with the fix.
- Focused race tests cover repeated toggles, continued loading/exhaustion, blocked in-flight loads, nested navigation/back, terminal escaping, and nonstreaming controls.
- `go test ./internal/...`
- `go test ./... -run '^$'`
- `go mod verify`
- `./scripts/lint` (build)
- Windows amd64 test cross-compilation; no Windows runtime or full interactive-terminal claim.
- Full `./scripts/test` passed against the pinned Steady local mock after direct loopback health verification, including the script's Windows cross-compilation phase. Synthetic credentials only.
