### PR TITLE
fix(requestflag): handle inner fields after null array objects

### DIFF
--- a/internal/requestflag/innerflag_test.go
+++ b/internal/requestflag/innerflag_test.go
@@ -1,9 +1,12 @@
 package requestflag
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v3"
 )
 
@@ -344,4 +347,87 @@ func TestInnerFlagWithSliceType(t *testing.T) {
 			{"name": "second"},
 		}, result)
 	})
+}
+
+func TestInnerFlagAfterNullArrayElement(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"null alone", []string{"--entry", "null"}, `{"entries":[null]}`},
+		{"inner field after null", []string{"--entry", "null", "--entry.name", "demo"}, `{"entries":[{"name":"demo"}]}`},
+		{"empty object control", []string{"--entry", "{}", "--entry.name", "demo"}, `{"entries":[{"name":"demo"}]}`},
+		{
+			"preserve earlier elements and merge siblings",
+			[]string{"--entry", "null", "--entry", "{name: earlier}", "--entry", "null", "--entry.name", "demo", "--entry.description", "details"},
+			`{"entries":[null,{"name":"earlier"},{"name":"demo","description":"details"}]}`,
+		},
+		{
+			"repeated field starts another element",
+			[]string{"--entry", "null", "--entry.name", "first", "--entry.description", "details", "--entry.name", "second"},
+			`{"entries":[{"name":"first","description":"details"},{"name":"second"}]}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			outer := &Flag[[]map[string]any]{Name: "entry", BodyPath: "entries"}
+			var body []byte
+			command := WithInnerFlags(cli.Command{
+				Name:  "test",
+				Flags: []cli.Flag{outer},
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					var err error
+					body, err = json.Marshal(ExtractRequestContents(cmd).Body)
+					return err
+				},
+			}, map[string][]HasOuterFlag{
+				"entry": {
+					&InnerFlag[string]{Name: "entry.name", InnerField: "name"},
+					&InnerFlag[string]{Name: "entry.description", InnerField: "description"},
+				},
+			})
+			require.NoError(t, command.Run(context.Background(), append([]string{"test"}, tt.args...)))
+			assert.JSONEq(t, tt.want, string(body))
+		})
+	}
+}
+
+func TestInnerFlagAfterNullArrayElementStdinPrecedence(t *testing.T) {
+	t.Parallel()
+
+	outer := &Flag[[]map[string]any]{Name: "entry", BodyPath: "entries"}
+	name := &InnerFlag[string]{Name: "entry.name", InnerField: "name", OuterFlag: outer}
+	description := &InnerFlag[string]{Name: "entry.description", InnerField: "description", OuterFlag: outer}
+	require.NoError(t, outer.Set(outer.Name, "null"))
+	require.NoError(t, name.Set(name.Name, "first"))
+	require.NoError(t, description.Set(description.Name, "first description"))
+	require.NoError(t, outer.Set(outer.Name, "null"))
+	require.NoError(t, name.Set(name.Name, "second"))
+
+	command := &cli.Command{Flags: []cli.Flag{outer, name, description}}
+	require.NoError(t, ApplyStdinDataToFlags(command, map[string]any{
+		"entries": map[string]any{"name": "stdin name", "description": "stdin description"},
+	}))
+	assert.Equal(t, []map[string]any{
+		{"name": "first", "description": "first description"},
+		{"name": "second", "description": "stdin description"},
+	}, outer.Get())
+}
+
+func TestInnerFlagAfterNullElementInUntypedArray(t *testing.T) {
+	t.Parallel()
+
+	outer := &Flag[any]{Name: "entry"}
+	require.NoError(t, outer.PreParse())
+	name := &InnerFlag[string]{
+		Name: "entry.name", InnerField: "name", OuterFlag: outer,
+		OuterIsArrayOfObjects: true,
+	}
+	require.NoError(t, name.Set(name.Name, "first"))
+	require.NoError(t, outer.Set(outer.Name, "null"))
+	require.NoError(t, name.Set(name.Name, "second"))
+	assert.Equal(t, []map[string]any{{"name": "first"}, {"name": "second"}}, outer.Get())
 }

--- a/internal/requestflag/requestflag.go
+++ b/internal/requestflag/requestflag.go
@@ -959,6 +959,10 @@ func (c *cliValue[T]) SetInnerField(field string, val any) {
 			// Check if the last element already has the InnerField
 			lastElement := flagValReflect.Index(sliceLen - 1).Interface().(map[string]any)
 			if _, hasInnerField := lastElement[field]; !hasInnerField {
+				if lastElement == nil {
+					lastElement = make(map[string]any)
+					flagValReflect.Index(sliceLen - 1).Set(reflect.ValueOf(lastElement))
+				}
 				// Last element doesn't have the field, set it
 				lastElement[field] = val
 				return


### PR DESCRIPTION
## Problem and fix

An inner field flag after a null array-object value panics while assigning into a nil map. Initialize that trailing map and store it in the existing slice slot before assigning the field.

With a fresh CLI build and an empty environment, this parser-only command previously exited 2 with `assignment to entry in nil map`; it now exits 0 and produces identical help to the `{}` control:

```sh
env -i PATH=/usr/bin:/bin /tmp/openai chat:completions create --function null --function.name demo --help
```

This is a parsing fix, not a claim that null alone is a valid API function schema. Explicit null without a later inner assignment remains null. Earlier elements, sibling merging, repeated-field creation of a new element, typed and seeded untyped arrays, and per-trailing-element CLI/stdin precedence remain intact. Generated command sources are unchanged.

## Regression coverage and validation

Added command-parsing/request-body regressions plus trailing-element stdin precedence and seeded untyped-array coverage. The new CLI regression failed at the nil-map assignment before the fix. Two consecutive independent review rounds were clean on the unchanged diff.

Passed:
- `go test ./internal/requestflag -count=1`
- `go test ./internal/...`
- `go test ./... -run '^$'` (compile-only)
- `go mod verify`
- `./scripts/lint` (Go build, not comprehensive static analysis)
- Fresh CLI build and the parser-only reproduction/control above
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/requestflag.test.exe ./internal/requestflag` (compilation only)
- `git diff --check`

Tests used synthetic local inputs and made no live API calls. Full mock integration and Windows runtime execution were not run. The committed-candidate custom-code budget check passed: +427/-68 = 495 lines against a 1000-line limit, with verified generated baselines.
