### PR TITLE
fix(jsonview): preserve raw API fields in lazy-loaded rows

### DIFF
--- a/internal/jsonview/explorer.go
+++ b/internal/jsonview/explorer.go
@@ -164,7 +164,12 @@ func (tv *TableView) loadMoreData() tea.Cmd {
 			msg.err = iterator.Err()
 			return msg
 		}
-		jsonBytes, err := json.Marshal(iterator.Current())
+		item := iterator.Current()
+		if hasRaw, ok := item.(hasRawJSON); ok {
+			msg.result = gjson.Parse(hasRaw.RawJSON())
+			return msg
+		}
+		jsonBytes, err := json.Marshal(item)
 		msg.err = err
 		if err == nil {
 			msg.result = gjson.ParseBytes(jsonBytes)

--- a/internal/jsonview/explorer_stream_test.go
+++ b/internal/jsonview/explorer_stream_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/help"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
@@ -23,6 +24,75 @@ func (it *explorerIterator) Err() error   { return nil }
 func explorerKey(v *JSONViewer, key string) tea.Cmd {
 	_, cmd := v.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)})
 	return cmd
+}
+
+func TestExplorerLazyLoadPreservesSDKResponse(t *testing.T) {
+	for _, raw := range []string{
+		`{"id":"model-demo","object":"model","created":1,"owned_by":"demo","extra":"preserved"}`,
+		`{"id":"model-demo","object":"model","created":1,"owned_by":"demo","extra":"preserved","shutdown_date":null}`,
+	} {
+		t.Run(raw, func(t *testing.T) {
+			var item openai.Model
+			require.NoError(t, json.Unmarshal([]byte(raw), &item))
+			preloaded, err := marshalItemsToJSONArray([]any{item})
+			require.NoError(t, err)
+			require.JSONEq(t, "["+raw+"]", string(preloaded))
+			view, err := newTableView("", gjson.ParseBytes(preloaded), false)
+			require.NoError(t, err)
+			it := &explorerIterator{items: []any{item}}
+			view.iterator = it
+			v := &JSONViewer{stack: []JSONView{view}, root: "test", help: help.New()}
+			v.resize(80, 24)
+
+			cmd := explorerKey(v, "j")
+			require.NotNil(t, cmd)
+			msg := cmd().(tableItemMsg)
+			require.NoError(t, msg.err)
+			require.Len(t, view.rowData, 1, "only the UI update may append rows")
+			v.Update(msg)
+			require.Len(t, view.rowData, 2)
+			require.JSONEq(t, raw, view.rowData[1].Raw)
+			for i := 0; i < 4; i++ {
+				explorerKey(v, "r")
+				require.Same(t, view, v.current())
+				require.JSONEq(t, raw, view.rowData[1].Raw)
+			}
+			view.table.SetCursor(1)
+			require.JSONEq(t, raw, v.getSelectedContent())
+			explorerKey(v, "l")
+			require.Equal(t, "[1]", v.current().GetPath())
+			require.JSONEq(t, raw, v.current().GetData().Raw)
+			require.Equal(t, 1, it.index)
+		})
+	}
+}
+
+func TestExplorerLazyLoadMarshalFallback(t *testing.T) {
+	for _, item := range []any{map[string]any{"id": "second", "value": nil}, make(chan int)} {
+		t.Run(fmt.Sprintf("%T", item), func(t *testing.T) {
+			view, err := newTableView("", gjson.Parse(`[{"id":"first"}]`), false)
+			require.NoError(t, err)
+			view.iterator = &explorerIterator{items: []any{item}}
+			v := &JSONViewer{stack: []JSONView{view}, root: "test", help: help.New()}
+			v.resize(80, 24)
+			cmd := explorerKey(v, "j")
+			require.NotNil(t, cmd)
+			msg := cmd().(tableItemMsg)
+			v.Update(msg)
+			require.False(t, view.isLoading)
+			if _, ok := item.(chan int); ok {
+				var marshalErr *json.UnsupportedTypeError
+				require.ErrorAs(t, msg.err, &marshalErr)
+				require.False(t, msg.result.Exists())
+				require.Len(t, view.rowData, 1)
+				require.Len(t, view.table.Rows(), 1)
+			} else {
+				require.NoError(t, msg.err)
+				require.Len(t, view.rowData, 2)
+				require.JSONEq(t, `{"id":"second","value":null}`, view.rowData[1].Raw)
+			}
+		})
+	}
 }
 
 func TestExplorerToggleRetainsLoadedItems(t *testing.T) {


### PR DESCRIPTION
## Problem and fix

Lazily loaded explorer rows re-marshal SDK response values, losing unknown response fields and turning an absent or null `shutdown_date` into `"0001-01-01T00:00:00Z"`. Preloaded rows already preserve those fields using `RawJSON()`.

Prefer the existing `RawJSON()` interface for each lazy-loaded item, matching preload and ordinary iterator output. Ordinary `json.Marshal` fallback and marshal-error delivery remain unchanged. Commands still return `tableItemMsg`; the UI update loop alone appends rows, preserving retention, navigation, iterator order, and nested/in-flight delivery across raw/formatted toggles.

## Regression and validation

The new regression unmarshals synthetic response JSON into the pinned `openai-go/v3` `Model` and exercises the current command-to-UI message flow. Both absent and null cases failed on main before the fix, showing the lost unknown field and synthesized timestamp; both now pass. It also covers repeated toggles, selected content/navigation, ordinary values, and marshal errors. Existing retention, in-flight/nested delivery, navigation, and terminal-sanitization tests pass. Two consecutive independent review rounds were clean on the unchanged diff.

Passed:
- `go test ./internal/jsonview -count=1`
- `go test ./internal/...`
- `go test ./... -run '^$'` (compile-only)
- `go mod verify`
- `./scripts/lint` (Go build)
- `go test -race ./internal/jsonview -count=1`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/jsonview.test.exe ./internal/jsonview` (compilation only)
- `git diff --check`

The full local `./scripts/test` workflow was deliberately not run: its mock commands capture non-TTY output and do not exercise interactive lazy loading. Direct SDK/UI component regressions and race tests cover the changed boundary. No local mock integration, PTY, live API, or Windows runtime testing is claimed.

The committed-candidate custom-code budget check passed: +427/-68 = 495 lines against a 1000-line limit, with five mixed files and verified generated baselines. Only handwritten explorer source and its existing regression suite changed.
