### PR TITLE
fix(autocomplete): use distinct status for no completion

### DIFF
--- a/internal/autocomplete/autocomplete.go
+++ b/internal/autocomplete/autocomplete.go
@@ -87,9 +87,9 @@ func NewShellCompletion(name string, usage string) ShellCompletion {
 type ShellCompletionBehavior int
 
 const (
-	ShellCompletionBehaviorDefault ShellCompletionBehavior = iota
-	ShellCompletionBehaviorFile                            = 10
-	ShellCompletionBehaviorNoComplete
+	ShellCompletionBehaviorDefault    ShellCompletionBehavior = iota
+	ShellCompletionBehaviorFile                               = 10
+	ShellCompletionBehaviorNoComplete                         = 11
 )
 
 type CompletionResult struct {

--- a/internal/autocomplete/protocol_test.go
+++ b/internal/autocomplete/protocol_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,6 +64,8 @@ func TestShellCompletionProtocol(t *testing.T) {
 		{"root value", []string{"--format", "candidate-"}, 11, "", ""},
 		{"nested local value", []string{"models", "list", "--max-items", "candidate-"}, 11, "", ""},
 		{"file value", []string{"--file", "candidate-"}, 10, "", "candidate-fixture.txt\n"},
+		{"spaced preceding value", []string{"--format", "two words", "--file", "candidate-"}, 10, "", "candidate-fixture.txt\n"},
+		{"empty preceding value", []string{"--format", "", "--file", "candidate-"}, 10, "", "candidate-fixture.txt\n"},
 		{"explicit file prefix", []string{"--format", "@candidate-"}, 11, "", "@candidate-fixture.txt\n"},
 		{"command prefix", []string{"mo"}, 0, "models\n", "models\n"},
 	} {
@@ -103,6 +106,7 @@ if ! type mapfile >/dev/null 2>&1; then
   }
 fi
 openai() {
+  printf '%s\0' "$@" > helper.argv
   "$test_binary" -test.run='^TestShellCompletionProtocolHelper$' -- openai "$@"
 }
 ` + script + `
@@ -122,6 +126,10 @@ done
 				require.NoError(t, command.Run())
 				require.Empty(t, stderr.String())
 				require.Equal(t, test.candidates, stdout.String())
+				argv, err := os.ReadFile(filepath.Join(dir, "helper.argv"))
+				require.NoError(t, err)
+				wantArgs := append([]string{"__complete", "--"}, test.args...)
+				require.Equal(t, strings.Join(wantArgs, "\x00")+"\x00", string(argv))
 			})
 		})
 	}

--- a/internal/autocomplete/protocol_test.go
+++ b/internal/autocomplete/protocol_test.go
@@ -1,0 +1,128 @@
+package autocomplete
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+func TestShellCompletionProtocolHelper(t *testing.T) {
+	if os.Getenv("OPENAI_CLI_COMPLETION_HELPER") != "1" {
+		return
+	}
+	root := &cli.Command{
+		Name: "openai", SkipFlagParsing: true,
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "format"},
+			&cli.StringFlag{Name: "file", TakesFile: true},
+		},
+		Commands: []*cli.Command{
+			{Name: "models", Commands: []*cli.Command{
+				{Name: "list", Flags: []cli.Flag{&cli.IntFlag{Name: "max-items"}}},
+			}},
+			{Name: "__complete", Hidden: true, SkipFlagParsing: true, Action: ExecuteShellCompletion},
+		},
+		ExitErrHandler: func(context.Context, *cli.Command, error) {},
+	}
+	err := root.Run(context.Background(), os.Args[slices.Index(os.Args, "--")+1:])
+	if exit, ok := err.(cli.ExitCoder); ok {
+		os.Exit(exit.ExitCode())
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func TestShellCompletionProtocol(t *testing.T) {
+	t.Parallel()
+
+	bash, bashErr := exec.LookPath("bash")
+	binary, err := os.Executable()
+	require.NoError(t, err)
+	script, err := shellCompletions[CompletionStyleBash](&cli.Command{}, "openai")
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		name       string
+		args       []string
+		code       int
+		output     string
+		candidates string
+	}{
+		{"root value", []string{"--format", "candidate-"}, 11, "", ""},
+		{"nested local value", []string{"models", "list", "--max-items", "candidate-"}, 11, "", ""},
+		{"file value", []string{"--file", "candidate-"}, 10, "", "candidate-fixture.txt\n"},
+		{"explicit file prefix", []string{"--format", "@candidate-"}, 11, "", "@candidate-fixture.txt\n"},
+		{"command prefix", []string{"mo"}, 0, "models\n", "models\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			env := append(os.Environ(), "OPENAI_CLI_COMPLETION_HELPER=1", "COMPLETION_STYLE=bash")
+			args := append([]string{"-test.run=^TestShellCompletionProtocolHelper$", "--", "openai", "__complete", "--"}, test.args...)
+			command := exec.Command(binary, args...)
+			command.Env = env
+			var stdout, stderr bytes.Buffer
+			command.Stdout, command.Stderr = &stdout, &stderr
+			err := command.Run()
+			code := 0
+			if exit, ok := err.(*exec.ExitError); ok {
+				code = exit.ExitCode()
+			} else {
+				require.NoError(t, err)
+			}
+			require.Empty(t, stderr.String())
+			assert.Equal(t, test.code, code)
+			require.Equal(t, test.output, stdout.String())
+
+			t.Run("rendered bash", func(t *testing.T) {
+				if bashErr != nil {
+					t.Skip("bash is not available")
+				}
+				dir := t.TempDir()
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "candidate-fixture.txt"), nil, 0o600))
+				probe := `
+test_binary=$1
+shift
+# Match the existing Bash tests' support for platforms with Bash 3.
+if ! type mapfile >/dev/null 2>&1; then
+  mapfile() {
+    COMPREPLY=()
+    local line
+    while IFS= read -r line; do COMPREPLY+=("$line"); done
+  }
+fi
+openai() {
+  "$test_binary" -test.run='^TestShellCompletionProtocolHelper$' -- openai "$@"
+}
+` + script + `
+COMP_WORDS=(openai "$@")
+COMP_CWORD=$((${#COMP_WORDS[@]} - 1))
+__openai_bash_autocomplete
+for candidate in "${COMPREPLY[@]}"; do
+  printf '%s\n' "$candidate"
+done
+`
+				args := append([]string{"-c", probe, "completion-probe", binary}, test.args...)
+				command := exec.Command(bash, args...)
+				command.Dir, command.Env = dir, env
+				stdout.Reset()
+				stderr.Reset()
+				command.Stdout, command.Stderr = &stdout, &stderr
+				require.NoError(t, command.Run())
+				require.Empty(t, stderr.String())
+				require.Equal(t, test.candidates, stdout.String())
+			})
+		})
+	}
+}

--- a/internal/autocomplete/shellscripts/bash_autocomplete.bash
+++ b/internal/autocomplete/shellscripts/bash_autocomplete.bash
@@ -6,7 +6,12 @@ ____APPNAME___bash_autocomplete() {
     local IFS=$'\n'
     cur="${COMP_WORDS[COMP_CWORD]}"
 
-    completions=$(COMPLETION_STYLE=bash "${COMP_WORDS[0]}" __complete -- "${COMP_WORDS[@]:1:$COMP_CWORD-1}" "$cur" 2>/dev/null)
+    local -a completion_args=()
+    local word_index
+    for ((word_index = 1; word_index <= COMP_CWORD; word_index++)); do
+      completion_args+=("${COMP_WORDS[word_index]}")
+    done
+    completions=$(COMPLETION_STYLE=bash "${COMP_WORDS[0]}" __complete -- "${completion_args[@]}" 2>/dev/null)
     exit_code=$?
 
     local last_token="$cur"


### PR DESCRIPTION
## Problem and result

Completing a non-file flag value such as `--format` or `models list --max-items` suggested unrelated filenames. The omitted Go constant expression made `ShellCompletionBehaviorNoComplete` repeat file status `10`, although all four bundled shell scripts already treat `11` as no completion.

Assign `NoComplete` explicitly to `11`, preserving Default `0` and File `10`. The Bash helper invocation also copies completion words individually into a quoted array: Bash 3.2 collapsed the previous array slice into one argument, preventing nested commands from reaching the intended no-completion behavior. Spaces and empty arguments are preserved. Inherited global-flag lookup/enumeration, colon reconstruction and hidden-flag behavior remain outside this change.

## Regression and validation

The subprocess regression exercises the real completion entrypoint and literal wire statuses, rendered Bash candidates with synthetic filename fixtures, and exact NUL-delimited helper arguments. File, explicit `@`, default-status, spaced-value and empty-value controls are covered. Two consecutive independent review rounds were clean on the unchanged final diff.

Passed on the final source:
- Full autocomplete suite and `go test -race ./internal/autocomplete/... -count=1` on Linux.
- Native macOS Bash 3.2.57 / Go 1.27.0 full autocomplete race suite, including all seven protocol cases. The original nested failure was reproduced before the repair.
- `go test ./internal/... -count=1`.
- `go test ./... -run '^$' -count=1` (compile only).
- `go mod verify`.
- `./scripts/lint` (Go build only).
- `go vet ./internal/autocomplete/...`, formatting, diff and Bash syntax checks.
- Windows amd64 test cross-compilation on Linux and separately on macOS; Windows runtime tests were not run.
- Fresh real CLI Bash and PowerShell synthetic probes preserving non-file suppression and file/explicit-`@` behavior.
- Trusted-main custom-code report/budget against the actual follow-up commit: verified generated snapshot, five unchanged mixed files, 495/1000 lines.

The native macOS full `./scripts/test -count=1` started the approved pinned Steady mock and executed the full suite, but **failed** solely at `TestFilesCreateCLICancelClosesStalledFIFO` (`multipartresource_unix_test.go:129`, expected broken pipe, got nil). The same isolated test failed identically on the immutable pre-repair commit and repaired source in the same environment. Its precise cause is undetermined; this PR does not alter or skip it. All other packages passed. Windows compilation was run separately because the full script stopped at that failure.

The Linux local full-mock run remains environmentally unverified because the pinned JSR dependency is unavailable in its verified cache and the normal bootstrap fetch failed. [CI run 34166447608](https://github.com/openai/openai-cli/actions/runs/34166447608) passed on head `16e05075f292b77658df7523baf65e5a99b6352e`, including the full Linux Steady mock suite, Windows test cross-compilation, and all nine artifact build targets.

Bash 3.2 rendered tests use the existing test-only `mapfile` shim. They establish argument-boundary/protocol behavior, not universal unshimmed stock Bash 3.2 completion support. Fish and Zsh were source-reviewed; native Fish execution was unavailable. No live API or customer data was used.

Compatibility: this restores the bundled scripts' existing protocol. Third-party completion consumers relying on the erroneous status `10` for non-file values will now receive `11`.

