### PR TITLE
fix(jsonview): use terminal rows for startup preload

### DIFF
--- a/internal/jsonview/explorer.go
+++ b/internal/jsonview/explorer.go
@@ -320,7 +320,7 @@ func ExploreJSONStream[T any](title string, it Iterator[T]) error {
 	anyIt := genericToAnyIterator(it)
 
 	preloadCount := 20
-	if termHeight, _, err := term.GetSize(os.Stdout.Fd()); err == nil {
+	if _, termHeight, err := term.GetSize(os.Stdout.Fd()); err == nil {
 		preloadCount = termHeight
 	}
 

--- a/internal/jsonview/explorer_preload_linux_test.go
+++ b/internal/jsonview/explorer_preload_linux_test.go
@@ -1,0 +1,58 @@
+package jsonview
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/charmbracelet/x/term"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+type preloadIterator struct {
+	next int
+	err  error
+}
+
+func (it *preloadIterator) Next() bool   { it.next++; return true }
+func (it *preloadIterator) Current() int { return it.next }
+func (it *preloadIterator) Err() error   { return it.err }
+
+func TestExploreJSONStreamPreloadUsesTerminalRows(t *testing.T) {
+	terminal, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		t.Skipf("pseudo-terminal unavailable: %v", err)
+	}
+	t.Cleanup(func() { require.NoError(t, terminal.Close()) })
+	require.True(t, term.IsTerminal(terminal.Fd()))
+
+	for _, size := range []unix.Winsize{{Col: 40, Row: 24}, {Col: 80, Row: 24}, {Col: 40, Row: 36}} {
+		t.Run(fmt.Sprintf("%dx%d", size.Col, size.Row), func(t *testing.T) {
+			require.NoError(t, unix.IoctlSetWinsize(int(terminal.Fd()), unix.TIOCSWINSZ, &size))
+			checkExplorerPreload(t, terminal, int(size.Row))
+		})
+	}
+}
+
+func TestExploreJSONStreamPreloadWithoutTerminal(t *testing.T) {
+	output, err := os.CreateTemp(t.TempDir(), "output")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, output.Close()) })
+	require.False(t, term.IsTerminal(output.Fd()))
+	checkExplorerPreload(t, output, 20)
+}
+
+func checkExplorerPreload(t *testing.T, output *os.File, want int) {
+	t.Helper()
+	previous := os.Stdout
+	os.Stdout = output
+	defer func() { os.Stdout = previous }()
+
+	// Stop at the existing post-preload error check, before starting the UI.
+	stop := errors.New("preload complete")
+	iter := &preloadIterator{err: stop}
+	require.ErrorIs(t, ExploreJSONStream("test", iter), stop)
+	require.Equal(t, want, iter.next)
+}


### PR DESCRIPTION
## Problem and change

The interactive explorer assigns the first `term.GetSize` result (columns) to its startup preload count. With 24 rows, widening a terminal from 40 to 80 columns therefore increases initial consumption from 40 to 80 items, and can reach an iterator error before the UI appears.

Use the second result (rows) for initial prefetch. Both widths now preload 24 items; a 36-row terminal preloads 36. The existing fallback of 20 on terminal-size errors remains. This does not impose a total item limit: existing lazy loading continues beyond the initial batch. RawJSON handling, retained rows, navigation, and iterator error behavior are unchanged.

Add a Linux PTY regression through `ExploreJSONStream` for asymmetric dimensions and nonterminal fallback. The test stops at the existing post-preload error check before starting the UI.

## Validation

- New regression failed against unchanged production code (expected 24/24/36, got 40/80/40), then passed after the tuple correction; fallback 20 passed both times.
- Seven external synthetic Linux PTY runs exercised actual UI startup/quit, both widths at 24 and 36 rows, an item-49 error boundary, and lazy navigation from item 24 through 26. No live API was used.
- Passed: `go test -mod=readonly ./internal/jsonview -count=1`, `go test -mod=readonly -race ./internal/jsonview -count=1`, `go test -mod=readonly ./internal/...`, `go test -mod=readonly ./... -run '^$'`, `go mod verify`, and `GOFLAGS=-mod=readonly ./scripts/lint` (build only).
- Passed Windows amd64 all-package test cross-compilation and Darwin arm64 jsonview test cross-compilation. These are compile checks, not platform runtime execution; the new PTY regression is Linux-only.
- After advancing the base to current main, the complete two-file patch remained byte-identical; internal tests and root compile-only checks passed again.
- **Not run locally:** the full `./scripts/test` mock suite. Verified pinned Steady/Deno setup could not download the JSR manifest in this environment. No network/security protection was bypassed. No native Mac test run is claimed; full mock validation remains for CI.
