### PR TITLE
fix(requestflag): preserve piped query arrays

### DIFF
--- a/internal/requestflag/requestflag.go
+++ b/internal/requestflag/requestflag.go
@@ -201,11 +201,7 @@ func applyStdinDataToFlags(cmd *cli.Command, data map[string]any, onSet func(cli
 			if !found {
 				continue
 			}
-			setVal, err := formatForFlagSet(val)
-			if err != nil {
-				return fmt.Errorf("cannot format piped value for flag %q: %w", flag.Names()[0], err)
-			}
-			if err := setFlagFromStdin(flag, setVal, onSet); err != nil {
+			if err := setRequestFlagFromStdin(flag, val, onSet); err != nil {
 				return err
 			}
 			break

--- a/internal/requestflag/stdincollection.go
+++ b/internal/requestflag/stdincollection.go
@@ -1,0 +1,69 @@
+package requestflag
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/urfave/cli/v3"
+)
+
+// Query flags accept a whole collection from stdin. Other request locations
+// retain their existing formatting and assignment rules.
+func setRequestFlagFromStdin(flag cli.Flag, value any, onSet func(cli.Flag)) error {
+	if setter, ok := flag.(interface{ setStdinCollection(any) (bool, error) }); ok {
+		if handled, err := setter.setStdinCollection(value); handled {
+			if err != nil {
+				return fmt.Errorf("cannot set flag %q from piped data: %w", flag.Names()[0], err)
+			}
+			if onSet != nil {
+				onSet(flag)
+			}
+			return nil
+		}
+	}
+	formatted, err := formatForFlagSet(value)
+	if err != nil {
+		return fmt.Errorf("cannot format piped value for flag %q: %w", flag.Names()[0], err)
+	}
+	return setFlagFromStdin(flag, formatted, onSet)
+}
+
+func (f *Flag[T]) setStdinCollection(value any) (bool, error) {
+	input := reflect.ValueOf(value)
+	typ := reflect.TypeFor[T]()
+	if f.QueryPath == "" || input.Kind() != reflect.Slice || typ.Kind() != reflect.Slice {
+		return false, nil
+	}
+
+	// Convert into a fresh value so errors cannot leave a partially assigned flag.
+	// Reuse element conversion to match repeated CLI arguments, without changing
+	// Set's append semantics or appending to a default collection.
+	var collection T
+	if !input.IsNil() {
+		collection = reflect.MakeSlice(typ, 0, input.Len()).Interface().(T)
+	}
+	parsed := &cliValue[T]{collection}
+	for i := 0; i < input.Len(); i++ {
+		element, err := formatForFlagSet(input.Index(i).Interface())
+		if err != nil {
+			return true, err
+		}
+		if err := parsed.Set(element); err != nil {
+			return true, err
+		}
+	}
+	if !f.applied {
+		if err := f.PreParse(); err != nil {
+			return true, err
+		}
+	}
+	if f.Validator != nil {
+		if err := f.Validator(parsed.value); err != nil {
+			return true, err
+		}
+	}
+	f.value = parsed
+	f.count++
+	f.hasBeenSet = true
+	return true, nil
+}

--- a/internal/requestflag/stdincollection_test.go
+++ b/internal/requestflag/stdincollection_test.go
@@ -1,0 +1,117 @@
+package requestflag
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+func TestStdinCollections(t *testing.T) {
+	for _, input := range []string{`{"include":["first","second"]}`, "include:\n  - first\n  - second\n"} {
+		t.Run(input, func(t *testing.T) {
+			var data map[string]any
+			require.NoError(t, yaml.Unmarshal([]byte(input), &data))
+			flag := &Flag[[]string]{Name: "include", QueryPath: "include"}
+			require.NoError(t, ApplyStdinDataToFlags(&cli.Command{Flags: []cli.Flag{flag}}, data))
+			require.Equal(t, []string{"first", "second"}, flag.Get())
+		})
+	}
+}
+
+func TestStdinCollectionContracts(t *testing.T) {
+	tests := []struct {
+		name      string
+		flag      cli.Flag
+		input     any
+		want      any
+		wantError bool
+	}{
+		{name: "empty", flag: &Flag[[]string]{Name: "value", QueryPath: "value", Default: []string{"default"}}, input: []any{}, want: []string{}},
+		{name: "typed nil", flag: &Flag[[]string]{Name: "value", QueryPath: "value"}, input: []string(nil), want: []string(nil)},
+		{name: "null scalar compatibility", flag: &Flag[[]string]{Name: "value", QueryPath: "value"}, input: nil, want: []string{"null"}},
+		{name: "string scalar compatibility", flag: &Flag[[]string]{Name: "value", QueryPath: "value"}, input: "first", want: []string{"first"}},
+		{name: "array looking scalar", flag: &Flag[[]string]{Name: "value", QueryPath: "value"}, input: `["first"]`, want: []string{`["first"]`}},
+		{name: "numeric", flag: &Flag[[]int64]{Name: "value", QueryPath: "value"}, input: []any{1, 2}, want: []int64{1, 2}},
+		{name: "numeric strings use CLI parsing", flag: &Flag[[]int64]{Name: "value", QueryPath: "value"}, input: []any{"0x10", "2"}, want: []int64{16, 2}},
+		{name: "float", flag: &Flag[[]float64]{Name: "value", QueryPath: "value"}, input: []any{1.5, 2.5}, want: []float64{1.5, 2.5}},
+		{name: "boolean", flag: &Flag[[]bool]{Name: "value", QueryPath: "value"}, input: []any{true, false}, want: []bool{true, false}},
+		{name: "invalid numeric", flag: &Flag[[]int64]{Name: "value", QueryPath: "value", Default: []int64{7}}, input: []any{1, "bad"}, want: []int64{7}, wantError: true},
+		{name: "header compatibility", flag: &Flag[[]string]{Name: "value", HeaderPath: "value"}, input: []any{"a", "b"}, want: []string{`["a","b"]`}},
+		{name: "path compatibility", flag: &Flag[[]string]{Name: "value", PathParam: "value"}, input: []any{"a", "b"}, want: []string{`["a","b"]`}},
+		{name: "body excluded", flag: &Flag[[]string]{Name: "value", BodyPath: "value"}, input: []any{"a", "b"}, want: []string(nil)},
+		{name: "body root excluded", flag: &Flag[[]string]{Name: "value", BodyRoot: true}, input: []any{"a", "b"}, want: []string(nil)},
+		{name: "any collection unchanged", flag: &Flag[any]{Name: "value", QueryPath: "value"}, input: []any{"a", "b"}, want: []any{"a", "b"}},
+		{name: "nullable scalar unchanged", flag: &Flag[*string]{Name: "value", QueryPath: "value"}, input: nil, want: (*string)(nil)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var recorded []cli.Flag
+			err := ApplyStdinDataToFlagsWithProvenance(&cli.Command{Flags: []cli.Flag{tt.flag}}, map[string]any{"value": tt.input}, func(f cli.Flag) { recorded = append(recorded, f) })
+			if tt.wantError {
+				require.ErrorContains(t, err, `cannot set flag "value" from piped data`)
+				require.False(t, tt.flag.IsSet())
+				require.Empty(t, recorded)
+			} else {
+				require.NoError(t, err)
+				inReq := tt.flag.(InRequest)
+				if inReq.GetBodyPath() == "" && !inReq.IsBodyRoot() {
+					require.True(t, tt.flag.IsSet())
+					require.Equal(t, []cli.Flag{tt.flag}, recorded)
+				} else {
+					require.Empty(t, recorded)
+					require.False(t, tt.flag.IsSet())
+				}
+			}
+			require.Equal(t, tt.want, tt.flag.Get())
+		})
+	}
+}
+
+func TestStdinCollectionAliasesAndExplicitPrecedence(t *testing.T) {
+	for _, explicit := range []bool{false, true} {
+		flag := &Flag[[]string]{Name: "include", Aliases: []string{"i"}, DataAliases: []string{"include_alias"}, QueryPath: "include"}
+		if explicit {
+			require.NoError(t, flag.Set("i", "explicit"))
+		}
+		var recorded []cli.Flag
+		command := &cli.Command{Flags: []cli.Flag{flag}}
+		require.NoError(t, ApplyStdinDataToFlagsWithProvenance(command, map[string]any{"include_alias": []any{"piped", "second"}}, func(f cli.Flag) { recorded = append(recorded, f) }))
+		if explicit {
+			require.Equal(t, []string{"explicit"}, flag.Get())
+			require.Empty(t, recorded)
+		} else {
+			require.Equal(t, []string{"piped", "second"}, flag.Get())
+			require.Equal(t, []cli.Flag{flag}, recorded)
+		}
+		require.Equal(t, 1, flag.Count())
+	}
+	flag := &Flag[[]string]{Name: "include", DataAliases: []string{"alias"}, QueryPath: "include"}
+	require.NoError(t, ApplyStdinDataToFlags(&cli.Command{Flags: []cli.Flag{flag}}, map[string]any{"include": []any{"canonical"}, "alias": []any{"alias"}}))
+	require.Equal(t, []string{"canonical"}, flag.Get())
+}
+
+func TestStdinCollectionUnsetAndValidation(t *testing.T) {
+	flag := &Flag[[]string]{Name: "include", QueryPath: "include", Default: []string{"default"}}
+	command := &cli.Command{Flags: []cli.Flag{flag}}
+	require.NoError(t, ApplyStdinDataToFlags(command, map[string]any{}))
+	require.False(t, flag.IsSet())
+	require.Empty(t, ExtractRequestContents(command).Queries)
+	flag.Validator = func(values []string) error {
+		if len(values) > 1 {
+			return fmt.Errorf("only one element")
+		}
+		return nil
+	}
+	require.ErrorContains(t, ApplyStdinDataToFlags(command, map[string]any{"include": []any{"a", "b"}}), "only one element")
+	require.False(t, flag.IsSet())
+	require.Equal(t, []string{"default"}, flag.Get())
+	require.Zero(t, flag.Count())
+	require.NoError(t, ApplyStdinDataToFlags(command, map[string]any{"include": []any{"a"}}))
+	require.Equal(t, []string{"a"}, flag.Get())
+	flag.Validator = nil
+	require.NoError(t, flag.Set("include", "b"))
+	require.Equal(t, []string{"a", "b"}, flag.Get())
+}

--- a/pkg/cmd/stdincollection_test.go
+++ b/pkg/cmd/stdincollection_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStdinQueryCollectionsEndToEnd(t *testing.T) {
+	binary := filepath.Join(t.TempDir(), "openai")
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", binary, "../../cmd/openai")
+	output, err := build.CombinedOutput()
+	require.NoError(t, err, "%s", output)
+	requests := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_synthetic","object":"response","output":[]}`)
+	}))
+	defer server.Close()
+	run := func(t *testing.T, stdin, mode string, flags ...string) string {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		args := append([]string{"--base-url", server.URL, "--api-key", "synthetic-key", "responses", "retrieve", "--response-id", "resp_synthetic"}, flags...)
+		command := exec.CommandContext(ctx, binary, args...)
+		for _, v := range os.Environ() {
+			if !strings.HasPrefix(v, "OPENAI_") {
+				command.Env = append(command.Env, v)
+			}
+		}
+		command.Env = append(command.Env, "OPENAI_UNTRUSTED_STDIN="+mode)
+		command.Stdin = strings.NewReader(stdin)
+		var stderr bytes.Buffer
+		command.Stderr = &stderr
+		stdout, err := command.Output()
+		require.NoError(t, err, "stdout=%s stderr=%s", stdout, stderr.String())
+		require.Empty(t, stderr.String())
+		select {
+		case query := <-requests:
+			t.Logf("exit=0 stderr=empty query=%s", query)
+			return query
+		default:
+			t.Fatal("CLI did not send a request")
+			return ""
+		}
+	}
+	for _, mode := range []string{"false", "true"} {
+		t.Run(mode, func(t *testing.T) {
+			explicit := run(t, "", mode, "--include", "first", "--include", "second")
+			require.Equal(t, "include%5B%5D=first&include%5B%5D=second", explicit)
+			for _, input := range []string{`{"include":["first","second"]}`, "include:\n  - first\n  - second\n"} {
+				require.Equal(t, explicit, run(t, input, mode))
+				require.Equal(t, "include%5B%5D=explicit", run(t, input, mode, "--include", "explicit"))
+			}
+			require.Empty(t, run(t, `{"include":[]}`, mode))
+		})
+	}
+	t.Run("untrusted references stay literal and explicit references remain trusted", func(t *testing.T) {
+		path := filepath.ToSlash(filepath.Join(t.TempDir(), "synthetic.txt"))
+		require.NoError(t, os.WriteFile(path, []byte("SYNTHETIC_FILE_CONTENT"), 0600))
+		values := []string{"@" + path, "@file://" + path, "@data://" + path, "\\@" + path}
+		input, err := json.Marshal(map[string]any{"include": values})
+		require.NoError(t, err)
+		query := run(t, string(input), "true")
+		require.NotContains(t, query, "SYNTHETIC_FILE_CONTENT")
+		decoded, err := url.ParseQuery(query)
+		require.NoError(t, err)
+		require.Equal(t, values, decoded["include[]"])
+		require.Equal(t, "include%5B%5D=SYNTHETIC_FILE_CONTENT", run(t, string(input), "true", "--include", "@"+path))
+	})
+}


### PR DESCRIPTION
Piped JSON or YAML query arrays were passed to the flag parser as one serialized element. For example, `responses retrieve` with `{"include":["first","second"]}` sent one `include[]` value containing the JSON array instead of the same two values produced by `--include first --include second`.

Assign typed query collections through the existing element converter, then set the complete collection once. Preserve explicit flag precedence, aliases, provenance, scalar/null compatibility, and existing header/path/body behavior. Conversion and validation failures do not leave a partially assigned collection. No generated commands, schemas, dependencies, or policy files change.

## Validation

Passed locally with Go 1.27.0 on Linux:

- `go test ./internal/...`
- `go test ./... -run '^$'` (compilation only)
- `go test ./internal/requestflag ./pkg/cmd -run 'Stdin|ApplyStdinDataToFlags' -count=1`
- The same focused tests with `-race`
- `go vet ./internal/requestflag ./pkg/cmd`
- `go mod verify`
- `./scripts/lint` (Go build)
- Windows amd64 test cross-compilation for all packages; no Windows runtime testing
- Fresh CLI/localhost HTTP captures: JSON/YAML parity with repeated flags, both stdin trust modes, explicit overrides, empty arrays, untrusted literal file references, and explicit trusted file expansion. The regression fails against the original implementation.
- Baseline-versus-candidate probes for decoded null, mixed, and object collections; successful candidate collections match repeated CLI elements in JSON and query encoding.
- Trusted-main custom-code check on the actual committed candidate: 495/1000 lines; isolation passes.

**Full local mock suite NOT RUN:** the pinned Steady setup/cache blocker persists; the supported launcher reports a missing cache, and the previously denied bootstrap was not retried or bypassed. Full hosted CI/mock tests and completed bot reviews with resolved feedback remain mandatory before SDK review.
