### PR TITLE
fix(output): honor case-insensitive explore format

### DIFF
--- a/pkg/cmd/cmdutil.go
+++ b/pkg/cmd/cmdutil.go
@@ -500,7 +500,7 @@ type hasRawJSON interface {
 func ShowJSONIterator[T any](iter jsonview.Iterator[T], itemsToDisplay int64, opts ShowJSONOpts) error {
 	opts.setDefaults()
 
-	if opts.Format == "explore" {
+	if strings.ToLower(opts.Format) == "explore" {
 		if isTerminal(opts.Stdout) {
 			return jsonview.ExploreJSONStream(opts.Title, iter)
 		}

--- a/pkg/cmd/cmdutil_format_test.go
+++ b/pkg/cmd/cmdutil_format_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShowJSONIteratorExploreFormatCase(t *testing.T) {
+	t.Setenv("FORCE_COLOR", "0")
+	for _, format := range []string{"explore", "EXPLORE", "ExPlOrE"} {
+		for _, explicit := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/explicit=%t", format, explicit), func(t *testing.T) {
+				stdout, err := os.CreateTemp(t.TempDir(), "stdout")
+				require.NoError(t, err)
+				defer stdout.Close()
+				var stderr bytes.Buffer
+				iter := &sliceIterator[map[string]any]{items: []map[string]any{
+					{"id": "first"},
+					{"id": "not-visited"},
+				}}
+
+				err = ShowJSONIterator(iter, 1, ShowJSONOpts{
+					Format:         format,
+					ExplicitFormat: explicit,
+					Stdout:         stdout,
+					Stderr:         &stderr,
+					Transform:      "id",
+				})
+				require.NoError(t, err)
+				output, err := os.ReadFile(stdout.Name())
+				require.NoError(t, err)
+				require.Equal(t, "\"first\"\n", string(output))
+				require.Equal(t, 1, iter.index, "must not consume the next item")
+				if explicit {
+					require.Equal(t, warningExploreNotSupported, stderr.String())
+				} else {
+					require.Empty(t, stderr.String())
+				}
+			})
+		}
+	}
+}
+
+func TestShowJSONIteratorExploreFormatCaseTTY(t *testing.T) {
+	if !isTerminal(os.Stdout) {
+		t.Skip("explorer dispatch regression requires a terminal stdout")
+	}
+	for _, format := range []string{"explore", "EXPLORE", "ExPlOrE"} {
+		t.Run(format, func(t *testing.T) {
+			// An iterator error stops explorer preloading before the interactive UI starts.
+			upstream := errors.New("synthetic iterator failure")
+			iter := &failingOutputIterator{
+				sliceIterator: sliceIterator[string]{items: []string{"first"}},
+				err:           upstream,
+			}
+			var stderr bytes.Buffer
+			err := ShowJSONIterator[string](iter, -1, ShowJSONOpts{
+				Format:         format,
+				ExplicitFormat: true,
+				Stdout:         os.Stdout,
+				Stderr:         &stderr,
+			})
+			require.ErrorIs(t, err, upstream)
+			require.Equal(t, 2, iter.index)
+			require.Empty(t, stderr.String())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`--format EXPLORE` and mixed-case spellings pass format validation, but list output compares the original value with `explore`. A successful list request then fails with `Invalid format`, while the lowercase spelling works.

Use the existing `strings.ToLower` convention at the shared iterator dispatch comparison. Case variants follow the existing interactive explorer path, or fall back to JSON with the same explicit-format warning for non-terminal output. The change leaves pagination, limits, transforms, and other output formats intact. Only handwritten output code and focused regression tests change.

## Validation

Local validation with Go 1.27.0 on Linux:

- Fresh clean-main CLI/localhost and PTY RED-before-GREEN proof for `EXPLORE` and `ExPlOrE`, with lowercase parity, exact stdout/stderr comparisons, limit/transform controls, and successful explorer row display and quit.
- Focused tests cover casing, explicit-only warnings, output, transforms, bounded consumption, and deterministic TTY dispatch through an upstream error.
- `go test ./internal/...`
- `go test ./... -run '^$'` (compilation only)
- Focused output/binary tests and output/explorer race checks
- Native Linux PTY checks for explorer dispatch, pager colors/escaping, and binary output
- `go vet ./pkg/cmd ./internal/jsonview`
- `go mod verify`
- `./scripts/lint` (Go build)
- Windows amd64 test cross-compilation for all packages; no native Windows execution
- Two consecutive independent local review rounds without findings
- Trusted-main custom-code check on the actual committed candidate: 495/1000 lines; isolation and generated-snapshot verification pass

**Full LOCAL mock suite NOT RUN:** the supported pinned Steady launcher reports `Missing or linked Steady cache`. The previously blocked setup route was not retried.

## Hosted validation

[Full CI passed](https://github.com/openai/openai-cli/actions/runs/34196145346) with Go 1.25.14. The hosted `./scripts/test` run started the pinned Steady mock server, passed the package tests, cross-compiled tests for Windows, and completed cleanup. This was Windows compilation, not native execution. The tested merge commit `f7c7f1cdb3af25c1a6d10a8b0550ed4e842d5d75` has the published head `7f8d764e9a01809a222e1a28644c3d52a51b9ec4` and current main as its parents.

Required checks and the trusted custom-code budget passed. Codex code and security reviews completed; Copilot reviewed both changed files and recommended approval with no comments. No bot findings remain.
