### PR TITLE
feat(output): honor NO_COLOR for JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ For details about specific commands, use the `--help` flag.
 | `OPENAI_MTLS_CLIENT_KEY_FILE` | no | `null` |
 | `OPENAI_UNTRUSTED_STDIN` | no | `false` |
 
+JSON and JSONL output (including the default `auto` format) use color on terminals,
+including when paged. Set `NO_COLOR` to any nonempty value, including `0`, to disable
+this default color. An empty or unset `NO_COLOR` leaves automatic color unchanged.
+`FORCE_COLOR=1` explicitly enables color even with `NO_COLOR` or redirected output;
+`FORCE_COLOR=0` explicitly disables it. Other `FORCE_COLOR` values use automatic behavior.
+
 ### Global flags
 
 - `--api-key` (can also be set with `OPENAI_API_KEY` env var)

--- a/pkg/cmd/cmdutil.go
+++ b/pkg/cmd/cmdutil.go
@@ -166,8 +166,8 @@ func streamToPagerWithPipe(label string, generateOutput func(w *os.File) error) 
 
 	// If we would be streaming to a terminal and aren't forcing color one way
 	// or the other, we should configure things to use color so the pager gets
-	// colorized input.
-	if isTerminal(os.Stdout) && os.Getenv("FORCE_COLOR") == "" {
+	// colorized input, unless NO_COLOR disables default color.
+	if isTerminal(os.Stdout) && os.Getenv("FORCE_COLOR") == "" && os.Getenv("NO_COLOR") == "" {
 		os.Setenv("FORCE_COLOR", "1")
 	}
 
@@ -361,6 +361,9 @@ func shouldUseColors(w io.Writer) bool {
 		if force == "0" {
 			return false
 		}
+	}
+	if os.Getenv("NO_COLOR") != "" {
+		return false
 	}
 	return isTerminal(w)
 }

--- a/pkg/cmd/cmdutil_color_test.go
+++ b/pkg/cmd/cmdutil_color_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/pretty"
+)
+
+// An unset value is distinct from an explicitly empty environment variable.
+func setColorEnvironment(t *testing.T, key, value string) {
+	t.Helper()
+	t.Setenv(key, value)
+	if value == "unset" {
+		require.NoError(t, os.Unsetenv(key))
+	}
+}
+
+func TestJSONColorEnvironment(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "output")
+	require.NoError(t, err)
+	defer file.Close()
+	for _, destination := range []struct {
+		name string
+		file *os.File
+	}{{"file", file}, {"stdout", os.Stdout}} {
+		for _, format := range []string{"json", "jsonl", "auto"} {
+			for _, noColor := range []string{"unset", "", "1", "0"} {
+				for _, force := range []string{"unset", "", "0", "1", "auto"} {
+					t.Run(fmt.Sprintf("%s/%s/no=%s/force=%s", destination.name, format, noColor, force), func(t *testing.T) {
+						setColorEnvironment(t, "NO_COLOR", noColor)
+						setColorEnvironment(t, "FORCE_COLOR", force)
+						res := gjson.Parse(`{"data":{"text":"quote\" slash\\ newline\n escape\u001b[31m","n":2}}`)
+						plain := []byte("{\n  \"text\": \"quote\\\" slash\\\\ newline\\n escape\\u001b[31m\",\n  \"n\": 2\n}\n")
+						if format == "jsonl" {
+							plain = []byte("{\"text\":\"quote\\\" slash\\\\ newline\\n escape\\u001b[31m\",\"n\":2}\n")
+						}
+						wantColor := force == "1" || (force != "0" && (noColor == "unset" || noColor == "") && isTerminal(destination.file))
+						want := plain
+						if wantColor {
+							want = pretty.Color(plain, pretty.TerminalStyle)
+						}
+						actual, err := formatJSONForOutput(res, ShowJSONOpts{Format: format, Transform: "data", Stdout: file}, destination.file)
+						require.NoError(t, err)
+						require.Equal(t, string(want), string(actual))
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestJSONColorEnvironmentPagerIterator(t *testing.T) {
+	for _, format := range []string{"json", "jsonl"} {
+		for _, noColor := range []string{"1", "0"} {
+			t.Run(format+"/no="+noColor, func(t *testing.T) {
+				outputPath := configureCapturePager(t)
+				setColorEnvironment(t, "FORCE_COLOR", "unset")
+				t.Setenv("NO_COLOR", noColor)
+				items := make([]map[string]any, 64)
+				for i := range items {
+					items[i] = map[string]any{"data": map[string]any{"message": "safe"}}
+				}
+				var stderr bytes.Buffer
+				iter := &sliceIterator[map[string]any]{items: items}
+				require.NoError(t, ShowJSONIterator(iter, -1, ShowJSONOpts{Format: format, Transform: "data", Stderr: &stderr}))
+				output, err := os.ReadFile(outputPath)
+				require.NoError(t, err)
+				line := "{\n  \"message\": \"safe\"\n}\n"
+				if format == "jsonl" {
+					line = "{\"message\":\"safe\"}\n"
+				}
+				require.Equal(t, bytes.Repeat([]byte(line), len(items)), output)
+				require.Empty(t, stderr.String())
+			})
+		}
+	}
+}

--- a/pkg/cmd/cmdutil_color_unix_test.go
+++ b/pkg/cmd/cmdutil_color_unix_test.go
@@ -1,0 +1,58 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestJSONColorEnvironmentPagerBackends(t *testing.T) {
+	for name, stream := range map[string]func(string, func(*os.File) error) error{
+		"pipe": streamToPagerWithPipe, "socket": streamOutputOSSpecific,
+	} {
+		for _, format := range []string{"json", "jsonl"} {
+			for _, noColor := range []string{"unset", "", "1", "0"} {
+				for _, force := range []string{"unset", "", "0", "1", "auto"} {
+					t.Run(name+"/"+format+"/no="+noColor+"/force="+force, func(t *testing.T) {
+						outputPath := configureCapturePager(t)
+						setColorEnvironment(t, "NO_COLOR", noColor)
+						setColorEnvironment(t, "FORCE_COLOR", force)
+						// The first item is formatted before the pager starts, the next after.
+						res := gjson.Parse(`{"message":"safe"}`)
+						opts := ShowJSONOpts{Format: format, Stdout: os.Stdout}
+						first, err := formatJSON(res, opts)
+						require.NoError(t, err)
+						require.NoError(t, stream("test", func(w *os.File) error {
+							if name == "socket" {
+								require.Equal(t, "parent-socket", w.Name(), "must exercise the socket backend")
+							}
+							if _, err := w.Write(first); err != nil {
+								return err
+							}
+							next, err := formatJSONForOutput(res, ShowJSONOpts{Format: format, Stdout: w}, os.Stdout)
+							if err != nil {
+								return err
+							}
+							_, err = w.Write(next)
+							return err
+						}))
+						output, err := os.ReadFile(outputPath)
+						require.NoError(t, err)
+						require.Equal(t, string(first)+string(first), string(output))
+						if noColor == "1" || noColor == "0" {
+							value, exists := os.LookupEnv("FORCE_COLOR")
+							require.Equal(t, force != "unset", exists)
+							if exists {
+								require.Equal(t, force, value, "pager must preserve the user's color choice")
+							}
+						}
+					})
+				}
+			}
+		}
+	}
+}

--- a/pkg/cmd/cmdutil_test.go
+++ b/pkg/cmd/cmdutil_test.go
@@ -719,6 +719,7 @@ func TestShowJSONIteratorRawOutputPreservesPipelineBytes(t *testing.T) {
 }
 
 func TestFormatJSONForOutputUsesFinalDestinationForColors(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
 	if !isTerminal(os.Stdout) {
 		t.Skip("color destination regression requires an interactive stdout terminal")
 	}
@@ -783,6 +784,7 @@ func TestShowJSONIteratorRawOutputEscapesPaginatedTerminalControls(t *testing.T)
 }
 
 func TestShowJSONIteratorPreservesPaginatedTerminalColors(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
 	for _, format := range []string{"json", "jsonl"} {
 		t.Run(format, func(t *testing.T) {
 			outputPath := configureCapturePager(t)

--- a/pkg/cmd/cmdutil_unix.go
+++ b/pkg/cmd/cmdutil_unix.go
@@ -33,8 +33,8 @@ func streamOutputOSSpecific(label string, generateOutput func(w *os.File) error)
 
 	// If we would be streaming to a terminal and aren't forcing color one way
 	// or the other, we should configure things to use color so the pager gets
-	// colorized input.
-	if isTerminal(os.Stdout) && os.Getenv("FORCE_COLOR") == "" {
+	// colorized input, unless NO_COLOR disables default color.
+	if isTerminal(os.Stdout) && os.Getenv("FORCE_COLOR") == "" && os.Getenv("NO_COLOR") == "" {
 		os.Setenv("FORCE_COLOR", "1")
 	}
 


### PR DESCRIPTION
## Summary

Honor nonempty `NO_COLOR` (including `0`) when JSON, JSONL, or default `auto` output would otherwise add terminal color. Empty or unset `NO_COLOR` preserves automatic behavior. Explicit `FORCE_COLOR=1` and `FORCE_COLOR=0` retain precedence, including redirected output.

Both pager backends now avoid injecting `FORCE_COLOR=1` when `NO_COLOR` is active, keeping buffered and streamed output consistent. The change adds focused regression tests and documents precedence; payloads, escaping, transforms, newlines, destinations, and iterator limits retain their behavior.

## Validation

Local Go 1.27.0 on Linux:

- Clean-main baseline and candidate CLI probes: 160 invocations each using the same synthetic localhost/PTY harness; 36 intended color-only changes, identical payloads/newlines after SGR-only stripping, all exits 0 and empty stderr.
- Native sized-PTY RED/GREEN regressions for JSON/JSONL, both pager backends, and pagination; native PTY race checks, including inherited `NO_COLOR`.
- Focused output/binary tests; `go test ./internal/...`; `go test ./... -run '^$'` (compilation only).
- `go mod verify`; `./scripts/lint` (Go build); focused vet and selected output race tests.
- All-package Windows amd64 test cross-compilation; no native Windows execution.
- Two consecutive independent local review rounds without findings on the final diff.
- Trusted-current-main custom-code check on committed `043aeaee842956f516fcac7abe4018e70a86bc1b`: 495/1000 lines, verified generated snapshot, isolation passed.

**Full local mock suite not run:** the supported pinned Steady launcher reports `Missing or linked Steady cache`. The previously blocked setup route was not retried. Hosted [CI and full mock tests](https://github.com/openai/openai-cli/actions/runs/34199924347) passed on the published head via test merge `254a0be7bc0847a447bd68f6b1bcb2051136418c`, using Go 1.25.14/Linux. The log confirms pinned mock integrity/health checks, all-package tests, Windows test cross-compilation, and cleanup.
